### PR TITLE
feat: add a positional argument 'path' to the arkanjo-preprocessor build

### DIFF
--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -2,19 +2,31 @@
 #include <cassert>
 #include <iomanip>
 #include <iostream>
+#include <optional>
 
 #include <arkanjo/base/config.hpp>
 #include <arkanjo/formatter/format_manager.hpp>
 
 using fm = FormatterManager;
 
-std::tuple<std::string, double, bool> PreprocessorBuild::read_parameters() {
+std::tuple<std::string, double, bool> PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
     fm::write(INITIAL_MESSAGE);
     std::string similarity_message;
-
-    fm::write(PROJECT_PATH_MESSAGE);
     std::string path_str;
-    std::cin >> path_str;
+
+    if (options && !options->extra_args.empty() && !options->extra_args[0].empty()) {
+        path_str = options->extra_args[0];
+
+        if (!fs::exists(path_str)) {
+            std::cout << ERROR_PATH_MESSAGE << "\n";
+            path_str.clear(); 
+        }
+    }
+
+    if (path_str.empty()) {
+        fm::write(PROJECT_PATH_MESSAGE);
+        std::cin >> path_str;
+    }
     fs::path path(path_str);
 
     fm::write(MINIMUM_SIMILARITY_MESSAGE);
@@ -88,7 +100,7 @@ PreprocessorBuild::PreprocessorBuild() { }
 PreprocessorBuild::PreprocessorBuild(bool force_preprocess) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     if (force_preprocess || !std::filesystem::exists(base_path / CONFIG_PATH)) {
-        auto [path, similarity, use_duplication_finder_by_tool] = read_parameters();
+        auto [path, similarity, use_duplication_finder_by_tool] = read_parameters(std::nullopt);
         preprocess(path, similarity, use_duplication_finder_by_tool);
     }
 }
@@ -115,7 +127,7 @@ bool PreprocessorBuild::validate(const ParsedOptions& options) {
 
 bool PreprocessorBuild::run([[maybe_unused]] const ParsedOptions& options) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
-    auto [path, similarity, use_duplication_finder_by_tool] = read_parameters();
+    auto [path, similarity, use_duplication_finder_by_tool] = read_parameters(options);
     preprocess(path, similarity, use_duplication_finder_by_tool);
 
     return true;

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -51,6 +51,7 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
     static constexpr const char* DUPLICATION_MESSAGE = "Finding duplication in the codebase... (this may take a while)"; ///< Duplication detection message
     static constexpr const char* SAVING_MESSAGE = "Saving results...";                                                   ///< Results saving message
     static constexpr const char* END_MESSAGE = "Finished preprocessing";                                                 ///< Completion message
+    static constexpr const char* ERROR_PATH_MESSAGE = "Provided path does not exist.";                 ///< Error message for invalid paths
 
     // Duplication finder selection messages
     static constexpr const char* MESSAGE_DUPLICATION_FINDER_TYPE_1 = "Enter the number of the duplication finder technique you want to use:";
@@ -60,12 +61,13 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
 
     /**
      * @brief Reads preprocessing parameters from user/config
+     * @param options Parsed command line options. std::nullopt represents default behavior.
      * @return tuple<string,double,bool>
      *         - Project path
      *         - Similarity threshold
      *         - Duplication finder selection flag
      */
-    std::tuple<std::string, double, bool> read_parameters();
+    std::tuple<std::string, double, bool> read_parameters(const std::optional<ParsedOptions>& options);
 
     /**
      * @brief Executes full preprocessing pipeline
@@ -76,6 +78,10 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
     void preprocess(const fs::path& path, double similarity, bool use_duplication_finder_by_tool);
 
   public:
+    static constexpr CliOption options_[] = {
+      {"path", 0, PositionalArgument, "Project path to preprocess."},
+      OPTION_END
+    };
     PreprocessorBuild();
 
     /**


### PR DESCRIPTION
Add a positional argument to arkanjo-preprocessor build. Thus, it is possible take advantage to the terminal auto complete to write the path to the arkanjo-preprocessor. 

For example: 
`./arkanjo-preprocessor build ../../trees/drm_amd/drivers/gpu/drm/amd/display`


Note: If this new argument is not provided, the path to the directory is requested by the tool (as before).