### PR TITLE
Feature: Add git diff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(GNUInstallDirs)
 set(THIRD_PARTY_BUILD_DIR "${CMAKE_BINARY_DIR}/third-party")
 
 include(cmake/TreeSitter.cmake)
+include(cmake/Libgit2.cmake)
 include(cmake/CompilerOptions.cmake)
 include(cmake/Targets.cmake)
 

--- a/cmake/Libgit2.cmake
+++ b/cmake/Libgit2.cmake
@@ -28,3 +28,15 @@ function(setup_libgit2)
 endfunction()
 
 setup_libgit2()
+
+
+# macOS needs explicit iconv linkage for libgit2
+if(APPLE)
+    find_library(ICONV_LIBRARY iconv)
+
+    if(ICONV_LIBRARY)
+        message(STATUS "Found iconv: ${ICONV_LIBRARY}")
+    else()
+        message(FATAL_ERROR "iconv library not found")
+    endif()
+endif()

--- a/cmake/Libgit2.cmake
+++ b/cmake/Libgit2.cmake
@@ -1,0 +1,30 @@
+include(FetchContent)
+
+function(setup_libgit2)
+    message(STATUS "Configuring libgit2 via FetchContent...")
+
+    FetchContent_Declare(
+        libgit2
+        GIT_REPOSITORY https://github.com/libgit2/libgit2.git
+        GIT_TAG        v1.9.1
+    )
+
+    set(BUILD_TESTS OFF CACHE BOOL "Disable libgit2 tests" FORCE)
+    set(BUILD_CLI OFF CACHE BOOL "Disable libgit2 CLI" FORCE)
+    set(USE_SSH OFF CACHE BOOL "Disable SSH support in libgit2" FORCE)
+    set(USE_HTTP_PARSER builtin CACHE STRING "Use builtin HTTP parser" FORCE)
+    set(USE_HTTPS OFF CACHE STRING "Disable HTTPS support" FORCE)
+    set(USE_BUNDLED_ZLIB ON CACHE BOOL "Use bundled zlib" FORCE)
+
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build libgit2 as static" FORCE)
+
+    FetchContent_MakeAvailable(libgit2)
+
+    if(TARGET libgit2)
+        message(STATUS "libgit2 target successfully configured!")
+    else()
+        message(FATAL_ERROR "Failed to configure libgit2: 'libgit2' target NOT found.")
+    endif()
+endfunction()
+
+setup_libgit2()

--- a/cmake/Libgit2.cmake
+++ b/cmake/Libgit2.cmake
@@ -1,7 +1,25 @@
 include(FetchContent)
+option(ARKANJO_USE_SYSTEM_LIBGIT2
+    "Use system-installed libgit2 if available"
+    ON
+)
 
 function(setup_libgit2)
-    message(STATUS "Configuring libgit2 via FetchContent...")
+
+    if(ARKANJO_USE_SYSTEM_LIBGIT2)
+        find_package(libgit2 CONFIG QUIET)
+
+        if(libgit2_FOUND)
+            message(STATUS "Using system-installed libgit2")
+
+            set(ARKANJO_LIBGIT2_TARGET git2 PARENT_SCOPE)
+            set(ARKANJO_LIBGIT2_SYSTEM TRUE PARENT_SCOPE)
+
+            return()
+        endif()
+    endif()
+
+    message(STATUS "System libgit2 not found, using FetchContent")
 
     FetchContent_Declare(
         libgit2
@@ -20,11 +38,13 @@ function(setup_libgit2)
 
     FetchContent_MakeAvailable(libgit2)
 
-    if(TARGET libgit2)
-        message(STATUS "libgit2 target successfully configured!")
-    else()
-        message(FATAL_ERROR "Failed to configure libgit2: 'libgit2' target NOT found.")
+    if(NOT TARGET libgit2)
+        message(FATAL_ERROR "Failed to configure libgit2")
     endif()
+
+    set(ARKANJO_LIBGIT2_TARGET libgit2 PARENT_SCOPE)
+    set(ARKANJO_LIBGIT2_SYSTEM FALSE PARENT_SCOPE)
+
 endfunction()
 
 setup_libgit2()

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -51,8 +51,20 @@ file(GLOB_RECURSE CORE_COMMANDS_SOURCES
 )
 add_library(core_commands ${CORE_COMMANDS_SOURCES})
 target_sources(core_commands PRIVATE ${GENERATED_FILE})
-target_include_directories(core_commands PUBLIC ${ARKANJO_INCLUDE_DIRS})
-target_link_libraries(core_commands PUBLIC core_base core_utils ${PARSER_LIBS} tree_sitter_core core_parser core_methods)
+target_include_directories(core_commands PUBLIC
+    ${ARKANJO_INCLUDE_DIRS}
+    ${libgit2_SOURCE_DIR}/include
+)
+target_link_libraries(core_commands PUBLIC 
+    core_base 
+    core_utils 
+    ${PARSER_LIBS} 
+    tree_sitter_core 
+    core_parser 
+    core_methods
+    # ---libgit2 dependencies---
+    libgit2 util xdiff llhttp pcre zlib
+)
 
 #
 file(GLOB_RECURSE CORE_CLI_SOURCES

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -64,6 +64,7 @@ target_link_libraries(core_commands PUBLIC
     core_methods
     # ---libgit2 dependencies---
     libgit2 util xdiff llhttp pcre zlib
+    ${ICONV_LIBRARY}
 )
 
 #

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -51,6 +51,19 @@ file(GLOB_RECURSE CORE_COMMANDS_SOURCES
 )
 add_library(core_commands ${CORE_COMMANDS_SOURCES})
 target_sources(core_commands PRIVATE ${GENERATED_FILE})
+
+if(ARKANJO_LIBGIT2_SYSTEM)
+    set(ARKANJO_LIBGIT2_LIBS git2)
+else()
+    set(ARKANJO_LIBGIT2_LIBS
+        libgit2
+        util
+        xdiff
+        llhttp
+        pcre
+        zlib
+    )
+endif()
 target_include_directories(core_commands PUBLIC
     ${ARKANJO_INCLUDE_DIRS}
     ${libgit2_SOURCE_DIR}/include
@@ -62,8 +75,7 @@ target_link_libraries(core_commands PUBLIC
     tree_sitter_core 
     core_parser 
     core_methods
-    # ---libgit2 dependencies---
-    libgit2 util xdiff llhttp pcre zlib
+    ${ARKANJO_LIBGIT2_LIBS}
     ${ICONV_LIBRARY}
 )
 

--- a/src/commands/git/git_diff_function.cpp
+++ b/src/commands/git/git_diff_function.cpp
@@ -1,0 +1,179 @@
+#include "git_diff_function.hpp"
+
+#include <git2.h>
+
+#include <iostream>
+#include <sstream>
+
+#include <arkanjo/formatter/format_manager.hpp>
+#include <arkanjo/base/function/function.hpp>
+#include <arkanjo/cli/cli_error.hpp>
+
+struct DiffOutputPayload {
+    std::ostream* output;
+    bool printed;
+};
+
+GitDiffFunction::GitDiffFunction(Similarity_Table* _similarity_table)
+    : similarity_table(_similarity_table) {}
+
+bool GitDiffFunction::validate(const ParsedOptions& options) {
+
+    if (options.args.count("help") > 0) {
+        return true;
+    }
+
+    if (options.extra_args.size() != 2) {
+        throw CLIError("Git diff command expects two function name patterns.");
+        return false;
+    }
+    return true;
+}
+
+bool GitDiffFunction::run(const ParsedOptions& options) {
+    // Make a copy of the patterns to format them for searching in the similarity table
+    const std::string first_pattern = format_pattern(options.extra_args[0]);
+    const std::string second_pattern = format_pattern(options.extra_args[1]);
+
+    std::vector<Path> first_candidates = find_matching_paths(first_pattern);
+    std::vector<Path> second_candidates = find_matching_paths(second_pattern);
+
+    Path first_path = choose_single_path(first_candidates, options.extra_args[0]);
+    Path second_path = choose_single_path(second_candidates, options.extra_args[1]);
+
+    std::cout << "Comparing functions: '" << first_path.build_function_name() << "' and '"
+              << second_path.build_function_name() << "'\n";
+
+    if (!similarity_table->is_similar(first_path, second_path)) {
+        std::cerr << "The selected functions are not flagged as duplicates in the similarity table.\n";
+        return false;
+    }
+
+    return diff_functions(first_path, second_path);
+}
+
+std::vector<Path> GitDiffFunction::find_matching_paths(const std::string& pattern) const {
+    std::vector<Path> matches;
+    for (const auto& path : similarity_table->get_path_list()) {
+        if (path.contains_given_pattern(pattern)) {
+            matches.push_back(path);
+        }
+    }
+    return matches;
+}
+
+const std::string GitDiffFunction::format_pattern(const std::string& pattern) const {
+    std::string result = pattern;
+
+    size_t pos = 0;
+    while ((pos = result.find("::", pos)) != std::string::npos) {
+        result.replace(pos, 2, "/");
+        pos += 1;
+    }
+
+    return result;
+}
+
+Path GitDiffFunction::choose_single_path(const std::vector<Path>& candidates, const std::string& pattern) const {
+    if (candidates.empty()) {
+        throw CLIError("No function found matching pattern: " + pattern);
+    }
+    if (candidates.size() > 1) {
+        std::ostringstream message;
+        message << "Multiple functions match the pattern '" << pattern << "':\n";
+        for (const auto& path : candidates) {
+            message << "  - " << path.format_path_message_in_pair() << "\n";
+        }
+        message << "Please use a more specific function name pattern.";
+        throw CLIError(message.str());
+    }
+    return candidates.front();
+}
+
+std::string GitDiffFunction::build_text_from_lines(const std::vector<std::string>& lines) {
+    std::string output;
+    output.reserve(lines.size() * 80);
+    for (const auto& line : lines) {
+        output += line;
+        output.push_back('\n');
+    }
+    return output;
+}
+
+int GitDiffFunction::print_diff_line(const git_diff_delta* /*delta*/, const git_diff_hunk* /*hunk*/, const git_diff_line* line, void* payload) {
+    auto* data = static_cast<DiffOutputPayload*>(payload);
+    data->printed = true;
+
+    if (!data->output || line->content_len <= 0) {
+        return 0;
+    }
+
+    auto formatter = FormatterManager::get_formatter();
+    std::string output_line;
+    std::string content(line->content, line->content_len);
+
+    switch (line->origin) {
+        case GIT_DIFF_LINE_ADDITION:
+            output_line = formatter->colorize("+"+ content , Utils::COLOR::GREEN) ;
+            break;
+        case GIT_DIFF_LINE_DELETION:
+            output_line = formatter->colorize("-" + content, Utils::COLOR::RED);
+            break;
+        case GIT_DIFF_LINE_CONTEXT:
+            output_line = std::string(" ") + content;
+            break;
+        case GIT_DIFF_LINE_FILE_HDR:
+        case GIT_DIFF_LINE_HUNK_HDR:
+            output_line = formatter->colorize(content, Utils::COLOR::CYAN);
+            break;
+        default:
+            output_line = content;
+            break;
+    }
+
+    data->output->write(output_line.data(), output_line.size());
+    return 0;
+}
+
+bool GitDiffFunction::diff_functions(const Path& first, const Path& second) const {
+    Function first_function(first);
+    Function second_function(second);
+    first_function.load();
+    second_function.load();
+
+    std::string first_text = build_text_from_lines(first_function.build_all_content());
+    std::string second_text = build_text_from_lines(second_function.build_all_content());
+
+    git_libgit2_init();
+
+    git_diff_options diff_options = GIT_DIFF_OPTIONS_INIT;
+
+    std::string old_as_path = "a/" + first.build_function_name();
+    std::string new_as_path = "b/" + second.build_function_name();
+    diff_options.old_prefix = old_as_path.c_str();
+    diff_options.new_prefix = new_as_path.c_str();
+
+    DiffOutputPayload payload{&std::cout, false};
+    int error = git_diff_buffers(
+        first_text.c_str(), first_text.size(), first.build_function_name().c_str(),
+        second_text.c_str(), second_text.size(), second.build_function_name().c_str(),
+        &diff_options,
+        nullptr,
+        nullptr,
+        nullptr,
+        &GitDiffFunction::print_diff_line,
+        &payload
+    );
+    git_libgit2_shutdown();
+
+    if (error != 0) {
+        std::cerr << "Failed to compute diff between functions. libgit2 error code: " << error << "\n";
+        return false;
+    }
+
+    if (!payload.printed) {
+        std::cout << "No differences found between the selected functions.\n";
+    }
+
+    return true;
+}

--- a/src/commands/git/git_diff_function.cpp
+++ b/src/commands/git/git_diff_function.cpp
@@ -41,9 +41,6 @@ bool GitDiffFunction::run(const ParsedOptions& options) {
     Path first_path = choose_single_path(first_candidates, options.extra_args[0]);
     Path second_path = choose_single_path(second_candidates, options.extra_args[1]);
 
-    std::cout << "Comparing functions: '" << first_path.build_function_name() << "' and '"
-              << second_path.build_function_name() << "'\n";
-
     if (!similarity_table->is_similar(first_path, second_path)) {
         std::cerr << "The selected functions are not flagged as duplicates in the similarity table.\n";
         return false;
@@ -100,6 +97,42 @@ std::string GitDiffFunction::build_text_from_lines(const std::vector<std::string
     return output;
 }
 
+int GitDiffFunction::print_diff_file(const git_diff_delta* delta, float, void* payload) {
+    auto* data = static_cast<DiffOutputPayload*>(payload);
+
+    if (!data->output)
+        return 0;
+
+    std::string old_file = "--- a/";
+    old_file += delta->old_file.path;
+    old_file += "\n";
+
+    std::string new_file = "+++ b/";
+    new_file += delta->new_file.path;
+    new_file += "\n";
+
+    data->output->write(old_file.data(), old_file.size());
+    data->output->write(new_file.data(), new_file.size());
+
+    return 0;
+}
+
+int GitDiffFunction::print_diff_hunk(const git_diff_delta*,const git_diff_hunk* hunk,void* payload) {
+    auto* data = static_cast<DiffOutputPayload*>(payload);
+
+    if (!data->output)
+        return 0;
+
+    auto formatter = FormatterManager::get_formatter();
+
+    std::string header(hunk->header, hunk->header_len);
+    header = formatter->colorize(header, Utils::COLOR::MAGENTA);
+
+    data->output->write(header.data(), header.size());
+
+    return 0;
+}
+
 int GitDiffFunction::print_diff_line(const git_diff_delta* /*delta*/, const git_diff_hunk* /*hunk*/, const git_diff_line* line, void* payload) {
     auto* data = static_cast<DiffOutputPayload*>(payload);
     data->printed = true;
@@ -121,10 +154,6 @@ int GitDiffFunction::print_diff_line(const git_diff_delta* /*delta*/, const git_
             break;
         case GIT_DIFF_LINE_CONTEXT:
             output_line = std::string(" ") + content;
-            break;
-        case GIT_DIFF_LINE_FILE_HDR:
-        case GIT_DIFF_LINE_HUNK_HDR:
-            output_line = formatter->colorize(content, Utils::COLOR::CYAN);
             break;
         default:
             output_line = content;
@@ -153,19 +182,14 @@ bool GitDiffFunction::diff_functions(const Path& first, const Path& second) cons
 
     git_diff_options diff_options = GIT_DIFF_OPTIONS_INIT;
 
-    std::string old_as_path = "a/" + first.build_function_name();
-    std::string new_as_path = "b/" + second.build_function_name();
-    diff_options.old_prefix = old_as_path.c_str();
-    diff_options.new_prefix = new_as_path.c_str();
-
     DiffOutputPayload payload{&std::cout, false};
     int error = git_diff_buffers(
         first_text.c_str(), first_text.size(), first.build_function_name().c_str(),
         second_text.c_str(), second_text.size(), second.build_function_name().c_str(),
         &diff_options,
+        &GitDiffFunction::print_diff_file,
         nullptr,
-        nullptr,
-        nullptr,
+        &GitDiffFunction::print_diff_hunk,
         &GitDiffFunction::print_diff_line,
         &payload
     );

--- a/src/commands/git/git_diff_function.cpp
+++ b/src/commands/git/git_diff_function.cpp
@@ -131,6 +131,11 @@ int GitDiffFunction::print_diff_line(const git_diff_delta* /*delta*/, const git_
             break;
     }
 
+    /* 
+        TODO: Perhaps should be a good idea use << operator instead of write, 
+        but for that we need to handle the string termination character, 
+        since content is not guaranteed to be null-terminated. 
+    */
     data->output->write(output_line.data(), output_line.size());
     return 0;
 }

--- a/src/commands/git/git_diff_function.hpp
+++ b/src/commands/git/git_diff_function.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <git2.h>
+
+#include <arkanjo/base/path.hpp>
+#include <arkanjo/base/similarity_table.hpp>
+#include <arkanjo/commands/command_base.hpp>
+
+/**
+ * @brief Generate a git-style diff between two duplicate functions.
+ *
+ * This command matches two function name patterns against the similarity
+ * table, validates that the functions are considered duplicates, and then
+ * uses libgit2's diff engine to render a patch between the two function
+ * bodies.
+ */
+class GitDiffFunction : public CommandBase<GitDiffFunction> {
+  public:
+    static constexpr CliOption options_[] = {
+        {"first_function", 0, PositionalArgument, "First function name pattern."},
+        {"second_function", 0, PositionalArgument, "Second function name pattern."},
+        OPTION_END
+    };
+    COMMAND_DESCRIPTION("Show a git-style diff for two duplicate functions found by the tool.")
+
+    explicit GitDiffFunction(Similarity_Table* _similarity_table);
+
+    bool validate(const ParsedOptions& options) override;
+    bool run(const ParsedOptions& options) override;
+
+  private:
+    Similarity_Table* similarity_table;
+
+    std::vector<Path> find_matching_paths(const std::string& pattern) const;
+    const std::string format_pattern(const std::string& pattern) const;
+    Path choose_single_path(const std::vector<Path>& candidates, const std::string& pattern) const;
+    bool diff_functions(const Path& first, const Path& second) const;
+    static int print_diff_line(const git_diff_delta* delta,
+                               const git_diff_hunk* hunk,
+                               const git_diff_line* line,
+                               void* payload);
+    static std::string build_text_from_lines(const std::vector<std::string>& lines);
+};

--- a/src/commands/git/git_diff_function.hpp
+++ b/src/commands/git/git_diff_function.hpp
@@ -38,6 +38,8 @@ class GitDiffFunction : public CommandBase<GitDiffFunction> {
     const std::string format_pattern(const std::string& pattern) const;
     Path choose_single_path(const std::vector<Path>& candidates, const std::string& pattern) const;
     bool diff_functions(const Path& first, const Path& second) const;
+    static int print_diff_file(const git_diff_delta* delta, float, void* payload);
+    static int print_diff_hunk(const git_diff_delta*,const git_diff_hunk* hunk,void* payload);
     static int print_diff_line(const git_diff_delta* delta,
                                const git_diff_hunk* hunk,
                                const git_diff_line* line,

--- a/src/orchestrator_commands.hpp
+++ b/src/orchestrator_commands.hpp
@@ -10,6 +10,7 @@
 #include "commands/finder/similar_function_finder.hpp"
 #include "commands/help/help.hpp"
 #include "commands/rand/random_selector.hpp"
+#include "commands/git/git_diff_function.hpp"
 
 namespace OrchestratorCommands {
     static constexpr const char* DEFAULT_COMMAND = "help";
@@ -26,6 +27,7 @@ namespace OrchestratorCommands {
             {{"random"}, [&]() { return std::make_unique<RandomSelector>(&table); }},
             {{"bigclone-formater"}, [&]() { return std::make_unique<BigCloneFormater>(&table); }},
             {{"bigclone-evaluator"}, [&]() { return std::make_unique<BigCloneTailorEvaluator>(&table); }},
+            {{"git-diff"}, [&]() { return std::make_unique<GitDiffFunction>(&table); }},
             {{"help"}, [&]() { return std::make_unique<Help>(commands); }},
             {{"preprocessor"}, [&]() { return nullptr; }}
         };


### PR DESCRIPTION
Refers to #1 

This PR is related to a new feature in Arkanjo. Now, it is possible to see the diff, like the git diff command, between two functions marked as similar from the Arkanjo preprocessor. For this resource, it was used the [libgit2](https://libgit2.org/) project as git tool.

How to use:

After running the `arkanjo preprocessor` command, the git-diff command is ready to be used. The syntax is arkanjo `git-diff <function_1_name> <function_2_name>`.

<img width="1748" height="214" alt="image" src="https://github.com/user-attachments/assets/0b3fdfcf-f70f-4ecf-986e-3446b85f4285" />

For those cases when there are multiple functions with the same name, it is also possible to pass the full path provided by the tool to see the git diff.

<img width="1784" height="477" alt="image" src="https://github.com/user-attachments/assets/b9761269-4c5b-41be-8205-14566ab3bbbd" />
