### PR TITLE
feat: add embedding-based semantic duplication detection method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ project(arkanjo
     LANGUAGES C CXX
 )
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 option(ENABLE_WARNINGS "Enable compiler warnings" OFF)
 option(ENABLE_TESTS "Build tests" ON)
 

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -43,8 +43,7 @@ file(GLOB_RECURSE CORE_METHODS_SOURCES
 add_library(core_methods ${CORE_METHODS_SOURCES})
 target_sources(core_methods PRIVATE ${GENERATED_FILE})
 target_include_directories(core_methods PUBLIC ${ARKANJO_INCLUDE_DIRS})
-target_link_libraries(core_methods PUBLIC core_base ${PARSER_LIBS} tree_sitter_core)
-
+target_link_libraries(core_methods PUBLIC core_base ${PARSER_LIBS} tree_sitter_core Threads::Threads)
 #
 file(GLOB_RECURSE CORE_COMMANDS_SOURCES
     src/commands/*.cpp

--- a/include/arkanjo/cli/parser_options.hpp
+++ b/include/arkanjo/cli/parser_options.hpp
@@ -37,6 +37,10 @@ struct ParsedOptions {
 
     /**
      * @brief List of extra arguments that are not options.
+     *
+     * Includes everything after a `--` separator: getopt stops option parsing
+     * at `--`, so those tokens are kept unchanged here and can be forwarded
+     * directly to a method-specific backend. 
      */
     std::vector<std::string> extra_args;
 };

--- a/include/arkanjo/methods/llm/llm_method.hpp
+++ b/include/arkanjo/methods/llm/llm_method.hpp
@@ -39,6 +39,7 @@ class LLMMethod : public IMethod {
     double similarity; ///< Similarity threshold for considering duplicates (0-100)
     std::optional<int> max_seq_length; ///< Override for the Python script's --max-seq-length (nullopt = use script default)
     std::optional<int> batch_size;     ///< Override for the Python script's --batch-size (nullopt = use script default)
+    std::optional<std::string> model;  ///< Override for the Python script's --model (nullopt = use script default)
 
     /**
      * @brief Builds the command that runs the Python embedding script.
@@ -75,10 +76,12 @@ class LLMMethod : public IMethod {
      * @param similarity_ Minimum similarity threshold (0-100) to consider as duplicate.
      * @param max_seq_length_ Optional override for the embedding script's max sequence length.
      * @param batch_size_ Optional override for the embedding script's batch size.
+     * @param model_ Optional override for the embedding model name (Hugging Face id).
      */
     LLMMethod(const fs::path& base_path_, double similarity_,
               std::optional<int> max_seq_length_ = std::nullopt,
-              std::optional<int> batch_size_ = std::nullopt);
+              std::optional<int> batch_size_ = std::nullopt,
+              std::optional<std::string> model_ = std::nullopt);
 
     void on_function(const FunctionData& fd) override;
 

--- a/include/arkanjo/methods/llm/llm_method.hpp
+++ b/include/arkanjo/methods/llm/llm_method.hpp
@@ -34,9 +34,9 @@ class LLMMethod : public IMethod {
 
     fs::path base_path;
     double similarity;
-    std::optional<int> max_seq_length; ///< Override for the Python script's --max-seq-length (nullopt = use script default)
-    std::optional<int> batch_size;     ///< Override for the Python script's --batch-size (nullopt = use script default)
-    std::optional<std::string> model;  ///< Override for the Python script's --model (nullopt = use script default)
+    std::optional<int> max_seq_length;
+    std::optional<int> batch_size;
+    std::optional<std::string> model;
 
     /**
      * @brief Builds the command that runs the Python embedding script.

--- a/include/arkanjo/methods/llm/llm_method.hpp
+++ b/include/arkanjo/methods/llm/llm_method.hpp
@@ -34,9 +34,7 @@ class LLMMethod : public IMethod {
 
     fs::path base_path;
     double similarity;
-    std::optional<int> max_seq_length;
-    std::optional<int> batch_size;
-    std::optional<std::string> model;
+    std::vector<std::string> pass_through_args;
 
     /**
      * @brief Builds the command that runs the Python embedding script.
@@ -71,14 +69,11 @@ class LLMMethod : public IMethod {
      * @brief Constructs the LLM detector.
      * @param base_path_ Root path of the codebase cache.
      * @param similarity_ Minimum similarity threshold (0-100) to consider as duplicate.
-     * @param max_seq_length_ Optional override for the embedding script's max sequence length.
-     * @param batch_size_ Optional override for the embedding script's batch size.
-     * @param model_ Optional override for the embedding model name (Hugging Face id).
+     * @param pass_through_args_ Raw arguments forwarded to the embedding script
+     *         (e.g. --max-seq-length, --batch-size, --model).
      */
     LLMMethod(const fs::path& base_path_, double similarity_,
-              std::optional<int> max_seq_length_ = std::nullopt,
-              std::optional<int> batch_size_ = std::nullopt,
-              std::optional<std::string> model_ = std::nullopt);
+              std::vector<std::string> pass_through_args_ = {});
 
     void on_function(const FunctionData& fd) override;
 

--- a/include/arkanjo/methods/llm/llm_method.hpp
+++ b/include/arkanjo/methods/llm/llm_method.hpp
@@ -6,9 +6,6 @@
  * function bodies using Hugging Face embeddings (model:
  * jinaai/jina-embeddings-v2-base-code), delegating the embedding and pairwise
  * comparison to a Python helper script located in the third-party folder.
- *
- * Defines the preprocessor/setup step of the tool, where we do a heavy
- * preprocessing of the input codebase to enable fast query response later.
  */
 
 #pragma once
@@ -33,10 +30,10 @@ namespace fs = std::filesystem;
  */
 class LLMMethod : public IMethod {
   private:
-    static constexpr const char* SAVING_MESSAGE = "Saving results..."; ///< Status message for saving output
+    static constexpr const char* SAVING_MESSAGE = "Saving results...";
 
-    fs::path base_path;  ///< Root path of the codebase cache to analyze
-    double similarity; ///< Similarity threshold for considering duplicates (0-100)
+    fs::path base_path;
+    double similarity;
     std::optional<int> max_seq_length; ///< Override for the Python script's --max-seq-length (nullopt = use script default)
     std::optional<int> batch_size;     ///< Override for the Python script's --batch-size (nullopt = use script default)
     std::optional<std::string> model;  ///< Override for the Python script's --model (nullopt = use script default)

--- a/include/arkanjo/methods/llm/llm_method.hpp
+++ b/include/arkanjo/methods/llm/llm_method.hpp
@@ -1,0 +1,86 @@
+/**
+ * @file llm_method.hpp
+ * @brief LLM-embedding-based code duplication detection
+ *
+ * Implements a duplication detector that computes semantic similarity between
+ * function bodies using Hugging Face embeddings (model:
+ * jinaai/jina-embeddings-v2-base-code), delegating the embedding and pairwise
+ * comparison to a Python helper script located in the third-party folder.
+ *
+ * Defines the preprocessor/setup step of the tool, where we do a heavy
+ * preprocessing of the input codebase to enable fast query response later.
+ */
+
+#pragma once
+
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <vector>
+#include <filesystem>
+#include <arkanjo/methods/method.hpp>
+
+namespace fs = std::filesystem;
+
+/**
+ * @brief Semantic duplication detector using LLM embeddings.
+ *
+ * Materializes each function body as a file under the source feature directory
+ * (same as the other methods), then invokes a Python script that embeds every
+ * function with a Hugging Face model and prints the pairwise similarities, which
+ * are parsed back into duplication entries.
+ */
+class LLMMethod : public IMethod {
+  private:
+    static constexpr const char* SAVING_MESSAGE = "Saving results..."; ///< Status message for saving output
+
+    fs::path base_path;  ///< Root path of the codebase cache to analyze
+    double similarity; ///< Similarity threshold for considering duplicates (0-100)
+    std::optional<int> max_seq_length; ///< Override for the Python script's --max-seq-length (nullopt = use script default)
+    std::optional<int> batch_size;     ///< Override for the Python script's --batch-size (nullopt = use script default)
+
+    /**
+     * @brief Builds the command that runs the Python embedding script.
+     * @param source_dir Directory containing the materialized function bodies.
+     * @return The full shell command string passed to popen.
+     */
+    std::string build_command(const fs::path& source_dir) const;
+
+    /**
+     * @brief Parses a single "path1<TAB>path2<TAB>similarity" output line.
+     * @param line Raw line read from the script's stdout.
+     * @param entry Output parameter receiving the parsed entry.
+     * @return bool True if the line was a valid result line, false otherwise.
+     */
+    bool parse_line(const std::string& line, DuplicationEntry& entry) const;
+
+    /**
+     * @brief Reads and parses all result lines from the script's stdout.
+     * @param pipe Open read pipe returned by popen.
+     * @return vector<DuplicationEntry> Parsed pairs filtered by the threshold.
+     */
+    std::vector<DuplicationEntry> read_results(FILE* pipe) const;
+
+    /**
+     * @brief Saves duplication results to output.
+     * @param file_duplication_pairs Pairs to save.
+     */
+    void save_duplications(std::vector<DuplicationEntry>& file_duplication_pairs) override;
+
+  public:
+    /**
+     * @brief Constructs the LLM detector.
+     * @param base_path_ Root path of the codebase cache.
+     * @param similarity_ Minimum similarity threshold (0-100) to consider as duplicate.
+     * @param max_seq_length_ Optional override for the embedding script's max sequence length.
+     * @param batch_size_ Optional override for the embedding script's batch size.
+     */
+    LLMMethod(const fs::path& base_path_, double similarity_,
+              std::optional<int> max_seq_length_ = std::nullopt,
+              std::optional<int> batch_size_ = std::nullopt);
+
+    void on_function(const FunctionData& fd) override;
+
+    void execute() override;
+};

--- a/include/arkanjo/parser/tree_sitter_parser.hpp
+++ b/include/arkanjo/parser/tree_sitter_parser.hpp
@@ -37,10 +37,21 @@ class TreeSitterParser {
         const std::shared_ptr<TSTree>& tree,
         std::function<void(const FunctionData&)> callback);
 
+    // Detects the language from the file extension and parses the source code.
+    // Returns nullptr when the language is not supported.
+    static std::shared_ptr<TSTree> parse_source(
+        const fs::path& file_path, const std::string& source_code);
+
   public:
     static void process_file(
-      const fs::path& file_path, const fs::path& relative_path, const std::string& source_code, 
+      const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
       std::function<void(const FunctionData&)> callback);
-    
+
+    // Emits a single FunctionData representing the whole file as one unit,
+    // so files can be compared against each other (file granularity).
+    static void process_file_as_unit(
+      const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
+      std::function<void(const FunctionData&)> callback);
+
     explicit TreeSitterParser() = default;
 };

--- a/include/arkanjo/parser/tree_sitter_parser.hpp
+++ b/include/arkanjo/parser/tree_sitter_parser.hpp
@@ -37,8 +37,6 @@ class TreeSitterParser {
         const std::shared_ptr<TSTree>& tree,
         std::function<void(const FunctionData&)> callback);
 
-    // Detects the language from the file extension and parses the source code.
-    // Returns nullptr when the language is not supported.
     static std::shared_ptr<TSTree> parse_source(
         const fs::path& file_path, const std::string& source_code);
 
@@ -47,8 +45,6 @@ class TreeSitterParser {
       const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
       std::function<void(const FunctionData&)> callback);
 
-    // Emits a single FunctionData representing the whole file as one unit,
-    // so files can be compared against each other (file granularity).
     static void process_file_as_unit(
       const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
       std::function<void(const FunctionData&)> callback);

--- a/src/commands/pre/build/function_breaker.cpp
+++ b/src/commands/pre/build/function_breaker.cpp
@@ -116,7 +116,6 @@ int FunctionBreaker::process(
 
         auto path = dirEntry.path();
         file_breaker(path, folder_path, on_function, granularity);
-
         size_files++;
     }
 

--- a/src/commands/pre/build/function_breaker.cpp
+++ b/src/commands/pre/build/function_breaker.cpp
@@ -60,6 +60,7 @@ std::string FunctionBreaker::create_info_json(
 void FunctionBreaker::file_breaker(
     const fs::path& file_path, const fs::path& folder_path,
     std::function<void(const FunctionData&)> on_function,
+    Granularity granularity,
     int minimum_lines
 ) {
     if (!fs::exists(file_path)) return;
@@ -73,7 +74,7 @@ void FunctionBreaker::file_breaker(
 
     std::string source_code = Utils::read_file(file_path);
 
-    TreeSitterParser::process_file(file_path, relative_path, source_code, [&](const FunctionData& function) {
+    auto handle_unit = [&](const FunctionData& function) {
         auto source = function.get_feature<SourceFeature>();
         auto metadata = function.get_feature<MetadataFeature>();
 
@@ -90,22 +91,31 @@ void FunctionBreaker::file_breaker(
         write_output(cfg.header_path, relative_path, function.function_name, metadata->signature);
         write_output(cfg.info_path, relative_path, function.function_name,
             create_info_json(metadata->line_declaration, metadata->start_number_line, metadata->end_number_line, relative_path, function.function_name));
-    });
+    };
+
+    if (granularity == Granularity::File) {
+        TreeSitterParser::process_file_as_unit(file_path, relative_path, source_code, handle_unit);
+    } else {
+        TreeSitterParser::process_file(file_path, relative_path, source_code, handle_unit);
+    }
 }
 
 // TODO: It's possible to add parallelism to this function.
 int FunctionBreaker::process(
-    const fs::path& folder_path, 
+    const fs::path& folder_path,
     std::function<void(const FunctionData&)> on_function,
-    int minimum_lines
+    int minimum_lines,
+    Granularity granularity
 ) {
+    (void)minimum_lines;
+
     int size_files = 0;
 
     for (const auto& dirEntry : fs::recursive_directory_iterator(folder_path)) {
         if (!dirEntry.is_regular_file()) continue;
 
         auto path = dirEntry.path();
-        file_breaker(path, folder_path, on_function);
+        file_breaker(path, folder_path, on_function, granularity);
 
         size_files++;
     }

--- a/src/commands/pre/build/function_breaker.hpp
+++ b/src/commands/pre/build/function_breaker.hpp
@@ -28,6 +28,18 @@
 namespace fs = std::filesystem;
 
 /**
+ * @brief Comparison granularity used when breaking the codebase.
+ *
+ * - Function: each function becomes an independent unit (default behaviour).
+ * - File: each whole file becomes a single unit, so files are compared
+ *   against each other instead of function by function.
+ */
+enum class Granularity {
+    Function,
+    File
+};
+
+/**
  * @brief Main function extraction processor
  *
  * Analyzes source code directories (C/C++/Java) and extracts each function
@@ -88,17 +100,21 @@ class FunctionBreaker {
     void file_breaker(
       const fs::path& file_path, const fs::path& folder_path,
       std::function<void(const FunctionData&)> on_function,
+      Granularity granularity = Granularity::Function,
       int minimum_lines = 0);
 
     public:
     /**
      * @brief Processes all files in directory
      * @param folder_path Directory path to process
+     * @param on_function Callback invoked for every extracted unit
+     * @param granularity Whether to break the codebase by function or by file
      */
     int process(
       const fs::path& folder_path,
       std::function<void(const FunctionData&)> on_function,
-      int minimum_lines = 0);
+      int minimum_lines = 0,
+      Granularity granularity = Granularity::Function);
 
     /**
      * @brief Constructs function breaker and processes directory

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -9,7 +9,7 @@
 using fm = FormatterManager;
 
 std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
-           std::optional<std::string>>
+           std::optional<std::string>, Granularity>
 PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
     fm::write(INITIAL_MESSAGE);
     std::string similarity_message;
@@ -57,6 +57,7 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
     std::optional<int> llm_max_seq_length;
     std::optional<int> llm_batch_size;
     std::optional<std::string> llm_model;
+    Granularity granularity = Granularity::Function;
     if (options) {
         auto it = options->args.find("llm-max-seq-length");
         if (it != options->args.end()) {
@@ -70,16 +71,28 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
         if (it != options->args.end()) {
             llm_model = it->second;
         }
+        it = options->args.find("granularity");
+        if (it != options->args.end()) {
+            if (it->second == "file") {
+                granularity = Granularity::File;
+            } else if (it->second == "function" || it->second.empty()) {
+                granularity = Granularity::Function;
+            } else {
+                throw CLIError("Invalid --granularity value: '" + it->second +
+                               "'. Use 'function' (default) or 'file'.");
+            }
+        }
     }
 
     return {path, similarity, use_duplication_finder_index, llm_max_seq_length,
-            llm_batch_size, llm_model};
+            llm_batch_size, llm_model, granularity};
 }
 
 void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
                                    std::optional<int> llm_max_seq_length,
                                    std::optional<int> llm_batch_size,
-                                   std::optional<std::string> llm_model) {
+                                   std::optional<std::string> llm_model,
+                                   Granularity granularity) {
     auto start = std::chrono::high_resolution_clock::now();
 
     fm::write(BREAKER_MESSAGE);
@@ -100,7 +113,7 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
     FunctionBreaker function_breaker;
     auto size_files = function_breaker.process(path, [&method](const FunctionData& fd) {
         method->on_function(fd);
-    }, minimum_lines);
+    }, minimum_lines, granularity);
 
     if (mode_verbose) {
         fm::write("\tFound " + std::to_string(size_files) + " files");
@@ -127,9 +140,9 @@ PreprocessorBuild::PreprocessorBuild(bool force_preprocess) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     if (force_preprocess || !std::filesystem::exists(base_path / CONFIG_PATH)) {
         auto [path, similarity, use_duplication_finder_index,
-              llm_max_seq_length, llm_batch_size, llm_model] = read_parameters(std::nullopt);
+              llm_max_seq_length, llm_batch_size, llm_model, granularity] = read_parameters(std::nullopt);
         preprocess(path, similarity, use_duplication_finder_index,
-                   llm_max_seq_length, llm_batch_size, llm_model);
+                   llm_max_seq_length, llm_batch_size, llm_model, granularity);
     }
 }
 
@@ -170,9 +183,9 @@ bool PreprocessorBuild::run([[maybe_unused]] const ParsedOptions& options) {
 
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     auto [path, similarity, use_duplication_finder_index,
-          llm_max_seq_length, llm_batch_size, llm_model] = read_parameters(options);
+          llm_max_seq_length, llm_batch_size, llm_model, granularity] = read_parameters(options);
     preprocess(path, similarity, use_duplication_finder_index,
-               llm_max_seq_length, llm_batch_size, llm_model);
+               llm_max_seq_length, llm_batch_size, llm_model, granularity);
 
     return true;
 }

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -8,7 +8,8 @@
 
 using fm = FormatterManager;
 
-std::tuple<std::string, double, size_t> PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
+std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>>
+PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
     fm::write(INITIAL_MESSAGE);
     std::string similarity_message;
     std::string path_str;
@@ -52,10 +53,25 @@ std::tuple<std::string, double, size_t> PreprocessorBuild::read_parameters(const
     }
     --use_duplication_finder_index;
 
-    return {path, similarity, use_duplication_finder_index};
+    std::optional<int> llm_max_seq_length;
+    std::optional<int> llm_batch_size;
+    if (options) {
+        auto it = options->args.find("llm-max-seq-length");
+        if (it != options->args.end()) {
+            llm_max_seq_length = std::stoi(it->second);
+        }
+        it = options->args.find("llm-batch-size");
+        if (it != options->args.end()) {
+            llm_batch_size = std::stoi(it->second);
+        }
+    }
+
+    return {path, similarity, use_duplication_finder_index, llm_max_seq_length, llm_batch_size};
 }
 
-void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index) {
+void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
+                                   std::optional<int> llm_max_seq_length,
+                                   std::optional<int> llm_batch_size) {
     auto start = std::chrono::high_resolution_clock::now();
 
     fm::write(BREAKER_MESSAGE);
@@ -70,7 +86,8 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
     }
 
     auto start_breaker = std::chrono::high_resolution_clock::now();
-    auto method = MethodsType[use_duplication_finder_index].create(base_path, similarity);
+    auto method = MethodsType[use_duplication_finder_index].create(
+        base_path, similarity, llm_max_seq_length, llm_batch_size);
 
     FunctionBreaker function_breaker;
     auto size_files = function_breaker.process(path, [&method](const FunctionData& fd) {
@@ -101,8 +118,10 @@ PreprocessorBuild::PreprocessorBuild() { }
 PreprocessorBuild::PreprocessorBuild(bool force_preprocess) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     if (force_preprocess || !std::filesystem::exists(base_path / CONFIG_PATH)) {
-        auto [path, similarity, use_duplication_finder_index] = read_parameters(std::nullopt);
-        preprocess(path, similarity, use_duplication_finder_index);
+        auto [path, similarity, use_duplication_finder_index,
+              llm_max_seq_length, llm_batch_size] = read_parameters(std::nullopt);
+        preprocess(path, similarity, use_duplication_finder_index,
+                   llm_max_seq_length, llm_batch_size);
     }
 }
 
@@ -142,8 +161,10 @@ bool PreprocessorBuild::run([[maybe_unused]] const ParsedOptions& options) {
     mode_verbose = options.args.count("verbose") > 0;
 
     fs::path base_path = Config::config().base_path / Config::config().name_container;
-    auto [path, similarity, use_duplication_finder_index] = read_parameters(options);
-    preprocess(path, similarity, use_duplication_finder_index);
+    auto [path, similarity, use_duplication_finder_index,
+          llm_max_seq_length, llm_batch_size] = read_parameters(options);
+    preprocess(path, similarity, use_duplication_finder_index,
+               llm_max_seq_length, llm_batch_size);
 
     return true;
 }

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -106,10 +106,10 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
             fm::write("Removed existing container folder");
     }
 
-    auto start_breaker = std::chrono::high_resolution_clock::now();
     auto method = MethodsType[use_duplication_finder_index].create(
         base_path, similarity, llm_max_seq_length, llm_batch_size, llm_model);
 
+    auto start_breaker = std::chrono::high_resolution_clock::now();
     FunctionBreaker function_breaker;
     auto size_files = function_breaker.process(path, [&method](const FunctionData& fd) {
         method->on_function(fd);

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -8,7 +8,8 @@
 
 using fm = FormatterManager;
 
-std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>>
+std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
+           std::optional<std::string>>
 PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
     fm::write(INITIAL_MESSAGE);
     std::string similarity_message;
@@ -55,6 +56,7 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
 
     std::optional<int> llm_max_seq_length;
     std::optional<int> llm_batch_size;
+    std::optional<std::string> llm_model;
     if (options) {
         auto it = options->args.find("llm-max-seq-length");
         if (it != options->args.end()) {
@@ -64,14 +66,20 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
         if (it != options->args.end()) {
             llm_batch_size = std::stoi(it->second);
         }
+        it = options->args.find("llm-model");
+        if (it != options->args.end()) {
+            llm_model = it->second;
+        }
     }
 
-    return {path, similarity, use_duplication_finder_index, llm_max_seq_length, llm_batch_size};
+    return {path, similarity, use_duplication_finder_index, llm_max_seq_length,
+            llm_batch_size, llm_model};
 }
 
 void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
                                    std::optional<int> llm_max_seq_length,
-                                   std::optional<int> llm_batch_size) {
+                                   std::optional<int> llm_batch_size,
+                                   std::optional<std::string> llm_model) {
     auto start = std::chrono::high_resolution_clock::now();
 
     fm::write(BREAKER_MESSAGE);
@@ -87,7 +95,7 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
 
     auto start_breaker = std::chrono::high_resolution_clock::now();
     auto method = MethodsType[use_duplication_finder_index].create(
-        base_path, similarity, llm_max_seq_length, llm_batch_size);
+        base_path, similarity, llm_max_seq_length, llm_batch_size, llm_model);
 
     FunctionBreaker function_breaker;
     auto size_files = function_breaker.process(path, [&method](const FunctionData& fd) {
@@ -119,9 +127,9 @@ PreprocessorBuild::PreprocessorBuild(bool force_preprocess) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     if (force_preprocess || !std::filesystem::exists(base_path / CONFIG_PATH)) {
         auto [path, similarity, use_duplication_finder_index,
-              llm_max_seq_length, llm_batch_size] = read_parameters(std::nullopt);
+              llm_max_seq_length, llm_batch_size, llm_model] = read_parameters(std::nullopt);
         preprocess(path, similarity, use_duplication_finder_index,
-                   llm_max_seq_length, llm_batch_size);
+                   llm_max_seq_length, llm_batch_size, llm_model);
     }
 }
 
@@ -162,9 +170,9 @@ bool PreprocessorBuild::run([[maybe_unused]] const ParsedOptions& options) {
 
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     auto [path, similarity, use_duplication_finder_index,
-          llm_max_seq_length, llm_batch_size] = read_parameters(options);
+          llm_max_seq_length, llm_batch_size, llm_model] = read_parameters(options);
     preprocess(path, similarity, use_duplication_finder_index,
-               llm_max_seq_length, llm_batch_size);
+               llm_max_seq_length, llm_batch_size, llm_model);
 
     return true;
 }

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -8,19 +8,21 @@
 
 using fm = FormatterManager;
 
-std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
-           std::optional<std::string>, Granularity>
+std::tuple<std::string, double, size_t, std::vector<std::string>, Granularity>
 PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) {
     fm::write(INITIAL_MESSAGE);
     std::string similarity_message;
     std::string path_str;
 
-    if (options && !options->extra_args.empty() && !options->extra_args[0].empty()) {
-        path_str = options->extra_args[0];
+    if (options) {
+        auto it_path = options->args.find("path");
+        if (it_path != options->args.end() && !it_path->second.empty()) {
+            path_str = it_path->second;
 
-        if (!fs::exists(path_str)) {
-            std::cout << ERROR_PATH_MESSAGE << "\n";
-            path_str.clear(); 
+            if (!fs::exists(path_str)) {
+                std::cout << ERROR_PATH_MESSAGE << "\n";
+                path_str.clear();
+            }
         }
     }
 
@@ -54,24 +56,12 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
     }
     --use_duplication_finder_index;
 
-    std::optional<int> llm_max_seq_length;
-    std::optional<int> llm_batch_size;
-    std::optional<std::string> llm_model;
+    std::vector<std::string> pass_through_args;
     Granularity granularity = Granularity::Function;
     if (options) {
-        auto it = options->args.find("llm-max-seq-length");
-        if (it != options->args.end()) {
-            llm_max_seq_length = std::stoi(it->second);
-        }
-        it = options->args.find("llm-batch-size");
-        if (it != options->args.end()) {
-            llm_batch_size = std::stoi(it->second);
-        }
-        it = options->args.find("llm-model");
-        if (it != options->args.end()) {
-            llm_model = it->second;
-        }
-        it = options->args.find("granularity");
+        pass_through_args = options->extra_args;
+
+        auto it = options->args.find("granularity");
         if (it != options->args.end()) {
             if (it->second == "file") {
                 granularity = Granularity::File;
@@ -84,14 +74,11 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
         }
     }
 
-    return {path, similarity, use_duplication_finder_index, llm_max_seq_length,
-            llm_batch_size, llm_model, granularity};
+    return {path, similarity, use_duplication_finder_index, pass_through_args, granularity};
 }
 
 void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
-                                   std::optional<int> llm_max_seq_length,
-                                   std::optional<int> llm_batch_size,
-                                   std::optional<std::string> llm_model,
+                                   const std::vector<std::string>& pass_through_args,
                                    Granularity granularity) {
     auto start = std::chrono::high_resolution_clock::now();
 
@@ -107,7 +94,7 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
     }
 
     auto method = MethodsType[use_duplication_finder_index].create(
-        base_path, similarity, llm_max_seq_length, llm_batch_size, llm_model);
+        base_path, similarity, pass_through_args);
 
     auto start_breaker = std::chrono::high_resolution_clock::now();
     FunctionBreaker function_breaker;
@@ -140,9 +127,9 @@ PreprocessorBuild::PreprocessorBuild(bool force_preprocess) {
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     if (force_preprocess || !std::filesystem::exists(base_path / CONFIG_PATH)) {
         auto [path, similarity, use_duplication_finder_index,
-              llm_max_seq_length, llm_batch_size, llm_model, granularity] = read_parameters(std::nullopt);
+              pass_through_args, granularity] = read_parameters(std::nullopt);
         preprocess(path, similarity, use_duplication_finder_index,
-                   llm_max_seq_length, llm_batch_size, llm_model, granularity);
+                   pass_through_args, granularity);
     }
 }
 
@@ -183,9 +170,9 @@ bool PreprocessorBuild::run([[maybe_unused]] const ParsedOptions& options) {
 
     fs::path base_path = Config::config().base_path / Config::config().name_container;
     auto [path, similarity, use_duplication_finder_index,
-          llm_max_seq_length, llm_batch_size, llm_model, granularity] = read_parameters(options);
+          pass_through_args, granularity] = read_parameters(options);
     preprocess(path, similarity, use_duplication_finder_index,
-               llm_max_seq_length, llm_batch_size, llm_model, granularity);
+               pass_through_args, granularity);
 
     return true;
 }

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -104,7 +104,7 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
            std::optional<std::string> model) {
           return std::make_unique<LLMMethod>(base_path, similarity, max_seq_length, batch_size, model);
         },
-        "Semantic similarity using Hugging Face embeddings (jinaai/jina-embeddings-v2-base-code)"
+        "Embedding-based similarity using a code language model"
       }
     };
 

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -120,7 +120,7 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
      *         - Optional LLM model name override
      */
     std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
-               std::optional<std::string>>
+               std::optional<std::string>, Granularity>
     read_parameters(const std::optional<ParsedOptions>& options);
 
     /**
@@ -135,7 +135,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
     void preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
                     std::optional<int> llm_max_seq_length = std::nullopt,
                     std::optional<int> llm_batch_size = std::nullopt,
-                    std::optional<std::string> llm_model = std::nullopt);
+                    std::optional<std::string> llm_model = std::nullopt,
+                    Granularity granularity = Granularity::Function);
 
   public:
     static constexpr CliOption options_[] = {
@@ -154,6 +155,10 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
         "Override the LLM detector's embedding model (Hugging Face "
         "sentence-transformers id). Only used by the LLM duplication finder; "
         "ignored by other methods."},
+      {"granularity", 0, RequiredArgument,
+        "Comparison granularity: 'function' (default) compares individual "
+        "functions; 'file' keeps each file whole and compares files against "
+        "each other. Applies to every duplication finder method."},
       OPTION_END
     };
     PreprocessorBuild();

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -28,7 +28,8 @@
 namespace fs = std::filesystem;
 
 using MethodFactory = std::function<std::unique_ptr<IMethod>(
-  const std::string&, float, std::optional<int>, std::optional<int>
+  const std::string&, float, std::optional<int>, std::optional<int>,
+  std::optional<std::string>
 )>;
 
 struct MethodInfo {
@@ -75,29 +76,33 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
     const std::vector<MethodInfo> MethodsType = {
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
+           std::optional<std::string> /*model*/) {
           return std::make_unique<ToolMethod>(base_path, similarity);
         },
         "NLP text similarity using gensim"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
+           std::optional<std::string> /*model*/) {
           return std::make_unique<DiffMethod>(base_path, similarity);
         },
         "Count proportion of equal lines using diff command"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
+           std::optional<std::string> /*model*/) {
           return std::make_unique<ASTMethod>(base_path, similarity);
         },
         "Compare linearized structural sequences extracted from Tree-sitter ASTs"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> max_seq_length, std::optional<int> batch_size) {
-          return std::make_unique<LLMMethod>(base_path, similarity, max_seq_length, batch_size);
+           std::optional<int> max_seq_length, std::optional<int> batch_size,
+           std::optional<std::string> model) {
+          return std::make_unique<LLMMethod>(base_path, similarity, max_seq_length, batch_size, model);
         },
         "Semantic similarity using Hugging Face embeddings (jinaai/jina-embeddings-v2-base-code)"
       }
@@ -112,8 +117,10 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
      *         - Duplication finder selection index
      *         - Optional LLM max sequence length override
      *         - Optional LLM batch size override
+     *         - Optional LLM model name override
      */
-    std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>>
+    std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
+               std::optional<std::string>>
     read_parameters(const std::optional<ParsedOptions>& options);
 
     /**
@@ -123,10 +130,12 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
      * @param use_duplication_finder_index Flag to select duplication detection method
      * @param llm_max_seq_length Optional LLM max sequence length override (ignored by non-LLM methods)
      * @param llm_batch_size Optional LLM batch size override (ignored by non-LLM methods)
+     * @param llm_model Optional LLM model name override (ignored by non-LLM methods)
      */
     void preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
                     std::optional<int> llm_max_seq_length = std::nullopt,
-                    std::optional<int> llm_batch_size = std::nullopt);
+                    std::optional<int> llm_batch_size = std::nullopt,
+                    std::optional<std::string> llm_model = std::nullopt);
 
   public:
     static constexpr CliOption options_[] = {
@@ -140,6 +149,10 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
       {"llm-batch-size", 0, RequiredArgument,
         "Override the LLM detector's embedding batch size. Lower this on "
         "machines with less RAM. Only used by the LLM duplication finder; "
+        "ignored by other methods."},
+      {"llm-model", 0, RequiredArgument,
+        "Override the LLM detector's embedding model (Hugging Face "
+        "sentence-transformers id). Only used by the LLM duplication finder; "
         "ignored by other methods."},
       OPTION_END
     };

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -28,8 +28,7 @@
 namespace fs = std::filesystem;
 
 using MethodFactory = std::function<std::unique_ptr<IMethod>(
-  const std::string&, float, std::optional<int>, std::optional<int>,
-  std::optional<std::string>
+  const std::string&, float, const std::vector<std::string>&
 )>;
 
 struct MethodInfo {
@@ -76,33 +75,29 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
     const std::vector<MethodInfo> MethodsType = {
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
-           std::optional<std::string> /*model*/) {
+           const std::vector<std::string>&) {
           return std::make_unique<ToolMethod>(base_path, similarity);
         },
         "NLP text similarity using gensim"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
-           std::optional<std::string> /*model*/) {
+           const std::vector<std::string>&) {
           return std::make_unique<DiffMethod>(base_path, similarity);
         },
         "Count proportion of equal lines using diff command"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/,
-           std::optional<std::string> /*model*/) {
+           const std::vector<std::string>&) {
           return std::make_unique<ASTMethod>(base_path, similarity);
         },
         "Compare linearized structural sequences extracted from Tree-sitter ASTs"
       },
       {
         [](const std::string& base_path, float similarity,
-           std::optional<int> max_seq_length, std::optional<int> batch_size,
-           std::optional<std::string> model) {
-          return std::make_unique<LLMMethod>(base_path, similarity, max_seq_length, batch_size, model);
+           const std::vector<std::string>& pass_through_args) {
+          return std::make_unique<LLMMethod>(base_path, similarity, pass_through_args);
         },
         "Embedding-based similarity using a code language model"
       }
@@ -115,12 +110,10 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
      *         - Project path
      *         - Similarity threshold
      *         - Duplication finder selection index
-     *         - Optional LLM max sequence length override
-     *         - Optional LLM batch size override
-     *         - Optional LLM model name override
+     *         - Pass-through arguments forwarded to the selected method's backend
+     *         - Comparison granularity
      */
-    std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>,
-               std::optional<std::string>, Granularity>
+    std::tuple<std::string, double, size_t, std::vector<std::string>, Granularity>
     read_parameters(const std::optional<ParsedOptions>& options);
 
     /**
@@ -128,33 +121,18 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
      * @param path Project path to process
      * @param similarity Similarity threshold
      * @param use_duplication_finder_index Flag to select duplication detection method
-     * @param llm_max_seq_length Optional LLM max sequence length override (ignored by non-LLM methods)
-     * @param llm_batch_size Optional LLM batch size override (ignored by non-LLM methods)
-     * @param llm_model Optional LLM model name override (ignored by non-LLM methods)
+     * @param pass_through_args Raw arguments forwarded to the selected method's
+     *        backend (everything after `--`); ignored by methods that take none
      */
     void preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
-                    std::optional<int> llm_max_seq_length = std::nullopt,
-                    std::optional<int> llm_batch_size = std::nullopt,
-                    std::optional<std::string> llm_model = std::nullopt,
+                    const std::vector<std::string>& pass_through_args = {},
                     Granularity granularity = Granularity::Function);
 
   public:
     static constexpr CliOption options_[] = {
       {"verbose", 0, NoArgument, "Enable verbose output"},
-      {"path", 0, PositionalArgument, "Project path to preprocess."},
+      {"path", 0, RequiredArgument, "Project path to preprocess."},
       {"minimum-lines", 0, RequiredArgument, "Minimum clone size in original lines."},
-      {"llm-max-seq-length", 0, RequiredArgument,
-        "Override the LLM detector's max token sequence length per function "
-        "(longer bodies are truncated). Only used by the LLM duplication "
-        "finder; ignored by other methods."},
-      {"llm-batch-size", 0, RequiredArgument,
-        "Override the LLM detector's embedding batch size. Lower this on "
-        "machines with less RAM. Only used by the LLM duplication finder; "
-        "ignored by other methods."},
-      {"llm-model", 0, RequiredArgument,
-        "Override the LLM detector's embedding model (Hugging Face "
-        "sentence-transformers id). Only used by the LLM duplication finder; "
-        "ignored by other methods."},
       {"granularity", 0, RequiredArgument,
         "Comparison granularity: 'function' (default) compares individual "
         "functions; 'file' keeps each file whole and compares files against "

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -15,10 +15,12 @@
 #include <arkanjo/methods/diff/diff_method.hpp>
 #include <arkanjo/methods/tool/tool_method.hpp>
 #include <arkanjo/methods/ast/ast_method.hpp>
+#include <arkanjo/methods/llm/llm_method.hpp>
 
 #include "function_breaker.hpp"
 #include <arkanjo/commands/pre/preprocessor.hpp>
 #include <arkanjo/commands/command_base.hpp>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <filesystem>
@@ -26,7 +28,7 @@
 namespace fs = std::filesystem;
 
 using MethodFactory = std::function<std::unique_ptr<IMethod>(
-  const std::string&, float
+  const std::string&, float, std::optional<int>, std::optional<int>
 )>;
 
 struct MethodInfo {
@@ -72,48 +74,73 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
 
     const std::vector<MethodInfo> MethodsType = {
       {
-        [](const std::string& base_path, float similarity) {
+        [](const std::string& base_path, float similarity,
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
           return std::make_unique<ToolMethod>(base_path, similarity);
         },
         "NLP text similarity using gensim"
       },
       {
-        [](const std::string& base_path, float similarity) {
+        [](const std::string& base_path, float similarity,
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
           return std::make_unique<DiffMethod>(base_path, similarity);
         },
         "Count proportion of equal lines using diff command"
       },
       {
-        [](const std::string& base_path, float similarity) {
+        [](const std::string& base_path, float similarity,
+           std::optional<int> /*max_seq_length*/, std::optional<int> /*batch_size*/) {
           return std::make_unique<ASTMethod>(base_path, similarity);
         },
         "Compare linearized structural sequences extracted from Tree-sitter ASTs"
+      },
+      {
+        [](const std::string& base_path, float similarity,
+           std::optional<int> max_seq_length, std::optional<int> batch_size) {
+          return std::make_unique<LLMMethod>(base_path, similarity, max_seq_length, batch_size);
+        },
+        "Semantic similarity using Hugging Face embeddings (jinaai/jina-embeddings-v2-base-code)"
       }
     };
 
     /**
      * @brief Reads preprocessing parameters from user/config
      * @param options Parsed command line options. std::nullopt represents default behavior.
-     * @return tuple<string,double,bool>
+     * @return tuple
      *         - Project path
      *         - Similarity threshold
-     *         - Duplication finder selection flag
+     *         - Duplication finder selection index
+     *         - Optional LLM max sequence length override
+     *         - Optional LLM batch size override
      */
-    std::tuple<std::string, double, size_t> read_parameters(const std::optional<ParsedOptions>& options);
+    std::tuple<std::string, double, size_t, std::optional<int>, std::optional<int>>
+    read_parameters(const std::optional<ParsedOptions>& options);
 
     /**
      * @brief Executes full preprocessing pipeline
      * @param path Project path to process
      * @param similarity Similarity threshold
      * @param use_duplication_finder_index Flag to select duplication detection method
+     * @param llm_max_seq_length Optional LLM max sequence length override (ignored by non-LLM methods)
+     * @param llm_batch_size Optional LLM batch size override (ignored by non-LLM methods)
      */
-    void preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index);
+    void preprocess(const fs::path& path, double similarity, size_t use_duplication_finder_index,
+                    std::optional<int> llm_max_seq_length = std::nullopt,
+                    std::optional<int> llm_batch_size = std::nullopt);
 
   public:
     static constexpr CliOption options_[] = {
       {"verbose", 0, NoArgument, "Enable verbose output"},
       {"path", 0, PositionalArgument, "Project path to preprocess."},
       {"minimum-lines", 0, RequiredArgument, "Minimum clone size in original lines."},
+      {"llm-max-seq-length", 0, RequiredArgument,
+        "Override the LLM detector's max token sequence length per function "
+        "(longer bodies are truncated). Only used by the LLM duplication "
+        "finder; ignored by other methods."},
+      {"llm-batch-size", 0, RequiredArgument,
+        "Override the LLM detector's embedding batch size. Lower this on "
+        "machines with less RAM. Only used by the LLM duplication finder; "
+        "ignored by other methods."},
       OPTION_END
     };
     PreprocessorBuild();

--- a/src/methods/llm/llm_method.cpp
+++ b/src/methods/llm/llm_method.cpp
@@ -15,11 +15,13 @@ using fm = FormatterManager;
 
 LLMMethod::LLMMethod(const fs::path& base_path_, double similarity_,
                      std::optional<int> max_seq_length_,
-                     std::optional<int> batch_size_) {
+                     std::optional<int> batch_size_,
+                     std::optional<std::string> model_) {
     base_path = base_path_;
     similarity = similarity_;
     max_seq_length = max_seq_length_;
     batch_size = batch_size_;
+    model = model_;
 
     if (similarity < 0) {
         std::cerr << "SIMILARITY SHOULD BE GREATER OR EQUAL 0 TO USE DUPLICATION FINDER BY LLM EMBEDDINGS";
@@ -41,6 +43,11 @@ std::string LLMMethod::build_command(const fs::path& source_dir) const {
     if (batch_size) {
         command += " --batch-size ";
         command += std::to_string(*batch_size);
+    }
+    if (model) {
+        command += " --model '";
+        command += *model;
+        command += "'";
     }
     return command;
 }

--- a/src/methods/llm/llm_method.cpp
+++ b/src/methods/llm/llm_method.cpp
@@ -14,14 +14,10 @@
 using fm = FormatterManager;
 
 LLMMethod::LLMMethod(const fs::path& base_path_, double similarity_,
-                     std::optional<int> max_seq_length_,
-                     std::optional<int> batch_size_,
-                     std::optional<std::string> model_) {
+                     std::vector<std::string> pass_through_args_) {
     base_path = base_path_;
     similarity = similarity_;
-    max_seq_length = max_seq_length_;
-    batch_size = batch_size_;
-    model = model_;
+    pass_through_args = std::move(pass_through_args_);
 
     if (similarity < 0) {
         std::cerr << "SIMILARITY SHOULD BE GREATER OR EQUAL 0 TO USE DUPLICATION FINDER BY LLM EMBEDDINGS";
@@ -36,17 +32,15 @@ std::string LLMMethod::build_command(const fs::path& source_dir) const {
     command += source_dir.string();
     command += " --min-similarity ";
     command += std::to_string(similarity);
-    if (max_seq_length) {
-        command += " --max-seq-length ";
-        command += std::to_string(*max_seq_length);
-    }
-    if (batch_size) {
-        command += " --batch-size ";
-        command += std::to_string(*batch_size);
-    }
-    if (model) {
-        command += " --model '";
-        command += *model;
+
+    for (const auto& arg : pass_through_args) {
+        command += " '";
+        for (char c : arg) {
+            if (c == '\'')
+                command += "'\\''";
+            else
+                command += c;
+        }
         command += "'";
     }
     return command;

--- a/src/methods/llm/llm_method.cpp
+++ b/src/methods/llm/llm_method.cpp
@@ -53,7 +53,6 @@ std::string LLMMethod::build_command(const fs::path& source_dir) const {
 }
 
 bool LLMMethod::parse_line(const std::string& line, DuplicationEntry& entry) const {
-    // Expected line format: path1 \t path2 \t similarity
     std::vector<std::string> tokens = Utils::split_string(line, '\t');
     if (tokens.size() != 3) {
         return false;

--- a/src/methods/llm/llm_method.cpp
+++ b/src/methods/llm/llm_method.cpp
@@ -1,0 +1,133 @@
+#include <arkanjo/methods/llm/llm_method.hpp>
+#include <arkanjo/formatter/format_manager.hpp>
+#include <arkanjo/base/config.hpp>
+#include <arkanjo/base/features/source_feature.hpp>
+#include <arkanjo/utils/utils.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+using fm = FormatterManager;
+
+LLMMethod::LLMMethod(const fs::path& base_path_, double similarity_,
+                     std::optional<int> max_seq_length_,
+                     std::optional<int> batch_size_) {
+    base_path = base_path_;
+    similarity = similarity_;
+    max_seq_length = max_seq_length_;
+    batch_size = batch_size_;
+
+    if (similarity < 0) {
+        std::cerr << "SIMILARITY SHOULD BE GREATER OR EQUAL 0 TO USE DUPLICATION FINDER BY LLM EMBEDDINGS";
+    }
+}
+
+std::string LLMMethod::build_command(const fs::path& source_dir) const {
+    std::string command = "python3 -W ignore ";
+    command += Config::config().third_party_dir.string();
+    command += "/llm-detection/llm_detection.py";
+    command += " --source-dir ";
+    command += source_dir.string();
+    command += " --min-similarity ";
+    command += std::to_string(similarity);
+    if (max_seq_length) {
+        command += " --max-seq-length ";
+        command += std::to_string(*max_seq_length);
+    }
+    if (batch_size) {
+        command += " --batch-size ";
+        command += std::to_string(*batch_size);
+    }
+    return command;
+}
+
+bool LLMMethod::parse_line(const std::string& line, DuplicationEntry& entry) const {
+    // Expected line format: path1 \t path2 \t similarity
+    std::vector<std::string> tokens = Utils::split_string(line, '\t');
+    if (tokens.size() != 3) {
+        return false;
+    }
+
+    try {
+        double sim = std::stod(tokens[2]);
+        entry = {sim, tokens[0], tokens[1]};
+    } catch (const std::exception&) {
+        return false;
+    }
+    return true;
+}
+
+std::vector<DuplicationEntry> LLMMethod::read_results(FILE* pipe) const {
+    std::vector<DuplicationEntry> pairs;
+    std::array<char, 4096> buffer{};
+    std::string leftover;
+
+    while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+        leftover += buffer.data();
+
+        size_t newline_pos;
+        while ((newline_pos = leftover.find('\n')) != std::string::npos) {
+            std::string line = leftover.substr(0, newline_pos);
+            leftover.erase(0, newline_pos + 1);
+
+            DuplicationEntry entry;
+            if (parse_line(line, entry) && std::get<0>(entry) >= similarity) {
+                pairs.push_back(entry);
+            }
+        }
+    }
+
+    sort(pairs.rbegin(), pairs.rend());
+    return pairs;
+}
+
+void LLMMethod::save_duplications(std::vector<DuplicationEntry>& file_duplication_pairs) {
+    std::string output_file_path = base_path / "output_parsed.txt";
+
+    auto fout = std::ofstream(output_file_path);
+
+    fout << file_duplication_pairs.size() << '\n';
+    for (const auto& [similarity, path1, path2] : file_duplication_pairs) {
+        fout << path1 << ' ' << path2 << ' ';
+        fout << std::fixed << std::setprecision(2) << similarity << '\n';
+    }
+
+    fout.close();
+}
+
+void LLMMethod::on_function(const FunctionData& fd) {
+    fs::path base = base_path / source_feature_path;
+
+    auto source = fd.get_feature<SourceFeature>();
+    if (!source)
+        return;
+
+    fs::path relative(fd.path);
+    std::string filename = fd.function_name + relative.extension().string();
+    fs::path path = base / relative / filename;
+    Utils::write_file(path, source->code + "\n");
+}
+
+void LLMMethod::execute() {
+    fs::path source_dir = base_path / source_feature_path;
+
+    std::string command = build_command(source_dir);
+
+    FILE* pipe = popen(command.c_str(), "r");
+    if (!pipe) {
+        std::cerr << "Error executing the LLM detection script.\n";
+        return;
+    }
+
+    std::vector<DuplicationEntry> file_duplication_pairs = read_results(pipe);
+
+    pclose(pipe);
+
+    fm::write(SAVING_MESSAGE);
+
+    save_duplications(file_duplication_pairs);
+}

--- a/src/parser/tree_sitter_parser.cpp
+++ b/src/parser/tree_sitter_parser.cpp
@@ -159,21 +159,19 @@ void TreeSitterParser::collect_functions(
     }
 }
 
-void TreeSitterParser::process_file(
+std::shared_ptr<TSTree> TreeSitterParser::parse_source(
     const fs::path& file_path,
-    const fs::path& relative_path,
-    const std::string& source_code,
-    std::function<void(const FunctionData&)> callback
+    const std::string& source_code
 ) {
     auto lang_name = detect_language(file_path);
 
-    if (lang_name.empty()) return;
+    if (lang_name.empty()) return nullptr;
 
     static auto language_map = get_language_map();
     auto it = language_map.find(lang_name);
     if (it == language_map.end()) {
         std::cerr << "Language not found: " << lang_name << "\n";
-        return;
+        return nullptr;
     }
     TSLanguage* language = it->second();
 
@@ -184,12 +182,12 @@ void TreeSitterParser::process_file(
     );
     if (current_language != language) {
         if (!ts_parser_set_language(parser.get(), language)) {
-            return;
+            return nullptr;
         }
         current_language = language;
     }
 
-    std::shared_ptr<TSTree> tree(
+    return std::shared_ptr<TSTree>(
         ts_parser_parse_string(
             parser.get(),
             nullptr,
@@ -198,9 +196,57 @@ void TreeSitterParser::process_file(
         ),
         ts_tree_delete
     );
+}
+
+void TreeSitterParser::process_file(
+    const fs::path& file_path,
+    const fs::path& relative_path,
+    const std::string& source_code,
+    std::function<void(const FunctionData&)> callback
+) {
+    std::shared_ptr<TSTree> tree = parse_source(file_path, source_code);
+    if (!tree) return;
+
     TSNode root_node = ts_tree_root_node(tree.get());
 
     collect_functions(root_node, source_code, relative_path, tree, callback);
+
+    tree.reset();
+}
+
+void TreeSitterParser::process_file_as_unit(
+    const fs::path& file_path,
+    const fs::path& relative_path,
+    const std::string& source_code,
+    std::function<void(const FunctionData&)> callback
+) {
+    std::shared_ptr<TSTree> tree = parse_source(file_path, source_code);
+    if (!tree) return;
+
+    TSNode root_node = ts_tree_root_node(tree.get());
+    TSPoint end = ts_node_end_point(root_node);
+
+    FunctionData function;
+    function.path = relative_path.string();
+    function.function_name = relative_path.stem().string();
+
+    auto source = std::make_shared<SourceFeature>();
+    source->code = source_code;
+    function.add_feature(source);
+
+    auto ast = std::make_shared<ASTFeature>();
+    ast->tree = tree;
+    ast->root = root_node;
+    function.add_feature(ast);
+
+    auto metadata = std::make_shared<MetadataFeature>();
+    metadata->signature = "";
+    metadata->line_declaration = 0;
+    metadata->start_number_line = 0;
+    metadata->end_number_line = end.row;
+    function.add_feature(metadata);
+
+    callback(function);
 
     tree.reset();
 }

--- a/third-party/llm-detection/embeddings-detection.md
+++ b/third-party/llm-detection/embeddings-detection.md
@@ -1,0 +1,65 @@
+# Embedding-based detection method
+
+A function-level code duplication detector that measures *semantic* similarity
+between function bodies. Instead of comparing tokens or lines, it embeds each
+function with a Hugging Face embedding model
+(default `jinaai/jina-embeddings-v2-base-code`) and computes the pairwise cosine
+similarity, scaled to a 0-100 range. This lets it flag functions that do the
+same thing even when names, formatting, or syntax differ.
+
+It is one of the four interchangeable detection techniques offered by the
+preprocessor (selected as option `4`): same input and output format as the
+others, so all query commands (`explorer`, `function`, `duplication`) work
+unchanged.
+
+## Preparing the environment
+
+The embedding dependencies are **not** installed with the rest of the project.
+Install them in the same `python3` interpreter that Arkanjo will call (watch out
+for virtualenvs):
+
+```sh
+python3 -m pip install -r third-party/llm-detection/requirements.txt
+```
+
+We recommend installing them inside a Python virtual environment (e.g. `venv`,
+`virtualenv`, or `conda`), and keeping that environment **activated** whenever
+you run the method — Arkanjo invokes the `python3` on your `PATH`, so the
+dependencies must be visible to the active interpreter. For example, with
+`venv`:
+
+```sh
+source .venv/bin/activate
+```
+
+The first run downloads the model (~hundreds of MB) to `~/.cache/huggingface`.
+On an offline machine, that cache must be pre-populated beforehand.
+
+## Parameters
+
+The method is selected and tuned through the preprocessor. The similarity
+threshold is asked interactively; the rest are optional CLI flags:
+
+```sh
+arkanjo-preprocessor build [path] \
+    [--llm-max-seq-length N] [--llm-batch-size N] [--llm-model NAME]
+```
+
+| Parameter | What it does | Default |
+| --- | --- | --- |
+| similarity threshold | Minimum similarity (0-100) for a pair to be reported. Asked at the prompt *"Enter minimum similarity desired"*. | `0.0` (everything is reported) |
+| `--llm-max-seq-length` | Maximum token length per function body; longer bodies are truncated. Attention memory grows as O(length²), so raising it sharply increases RAM use. | `1024` |
+| `--llm-batch-size` | How many function bodies are embedded in parallel. Lower it on machines with less RAM. | `4` |
+| `--llm-model` | Hugging Face `sentence-transformers` model used to embed the bodies. Any compatible Hub model works. | `jinaai/jina-embeddings-v2-base-code` |
+
+These flags are specific to the `llm` technique and are ignored by the other
+methods. When omitted, the defaults above are used.
+
+## Notes
+
+- **Cost is O(n²)**: every function is compared against every other. The
+  embedding step is vectorized, but the comparison matrix sets the cost ceiling
+  on large codebases.
+- To switch the embedding model permanently, either pass `--llm-model` or edit
+  the `MODEL_NAME` constant at the top of
+  `third-party/llm-detection/llm_detection.py`.

--- a/third-party/llm-detection/embeddings-detection.md
+++ b/third-party/llm-detection/embeddings-detection.md
@@ -38,28 +38,26 @@ On an offline machine, that cache must be pre-populated beforehand.
 ## Parameters
 
 The method is selected and tuned through the preprocessor. The similarity
-threshold is asked interactively; the rest are optional CLI flags:
+threshold is asked interactively. Method-specific args are passed after a `--`
+separator and forwarded to the embedding script:
 
 ```sh
-arkanjo-preprocessor build [path] \
-    [--llm-max-seq-length N] [--llm-batch-size N] [--llm-model NAME]
+arkanjo-preprocessor build --path <path> \
+    -- [--max-seq-length N] [--batch-size N] [--model NAME]
 ```
 
 | Parameter | What it does | Default |
 | --- | --- | --- |
 | similarity threshold | Minimum similarity (0-100) for a pair to be reported. Asked at the prompt *"Enter minimum similarity desired"*. | `0.0` (everything is reported) |
-| `--llm-max-seq-length` | Maximum token length per function body; longer bodies are truncated. Attention memory grows as O(length²), so raising it sharply increases RAM use. | `1024` |
-| `--llm-batch-size` | How many function bodies are embedded in parallel. Lower it on machines with less RAM. | `4` |
-| `--llm-model` | Hugging Face `sentence-transformers` model used to embed the bodies. Any compatible Hub model works. | `jinaai/jina-embeddings-v2-base-code` |
-
-These flags are specific to the `llm` technique and are ignored by the other
-methods. When omitted, the defaults above are used.
+| `--max-seq-length` | Maximum token length per function body; longer bodies are truncated. Attention memory grows as O(length²), so raising it sharply increases RAM use. | `1024` |
+| `--batch-size` | How many function bodies are embedded in parallel. Lower it on machines with less RAM. | `4` |
+| `--model` | Hugging Face `sentence-transformers` model used to embed the bodies. Any compatible Hub model works. | `jinaai/jina-embeddings-v2-base-code` |
 
 ## Notes
 
 - **Cost is O(n²)**: every function is compared against every other. The
   embedding step is vectorized, but the comparison matrix sets the cost ceiling
   on large codebases.
-- To switch the embedding model permanently, either pass `--llm-model` or edit
+- To switch the embedding model, either pass `-- --model NAME` or edit
   the `MODEL_NAME` constant at the top of
   `third-party/llm-detection/llm_detection.py`.

--- a/third-party/llm-detection/llm_detection.py
+++ b/third-party/llm-detection/llm_detection.py
@@ -61,12 +61,12 @@ def read_function_bodies(file_paths):
     return bodies
 
 
-def compute_embeddings(bodies, max_seq_length, batch_size):
+def compute_embeddings(bodies, max_seq_length, batch_size, model_name):
     import numpy as np
     from sentence_transformers import SentenceTransformer
 
-    log(f"Loading model {MODEL_NAME} (first run downloads weights)...")
-    model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
+    log(f"Loading model {model_name} (first run downloads weights)...")
+    model = SentenceTransformer(model_name, trust_remote_code=True)
     model.max_seq_length = max_seq_length
 
     log(f"Embedding {len(bodies)} function bodies "
@@ -135,6 +135,15 @@ def main():
             f"machines with less RAM. Default: {DEFAULT_BATCH_SIZE}."
         ),
     )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default=MODEL_NAME,
+        help=(
+            "Hugging Face sentence-transformers model used to embed function "
+            f"bodies. Default: {MODEL_NAME}."
+        ),
+    )
     args = parser.parse_args()
 
     file_paths = find_function_files(args.source_dir)
@@ -143,7 +152,7 @@ def main():
         return 0
 
     bodies = read_function_bodies(file_paths)
-    embeddings = compute_embeddings(bodies, args.max_seq_length, args.batch_size)
+    embeddings = compute_embeddings(bodies, args.max_seq_length, args.batch_size, args.model)
 
     # Emit paths relative to the source dir (e.g. "file.c/function.c"). The query
     # side treats each path as a resource path resolved against the source/info/

--- a/third-party/llm-detection/llm_detection.py
+++ b/third-party/llm-detection/llm_detection.py
@@ -1,34 +1,14 @@
 #!/usr/bin/env python3
-"""LLM-embedding based code duplication detector for arkanjo.
-
-Reads every materialized function body under --source-dir, embeds each one with a
-Hugging Face model (jinaai/jina-embeddings-v2-base-code) through the
-sentence-transformers library, computes the pairwise cosine similarity scaled to
-a 0-100 range, and prints the pairs whose similarity is greater than or equal to
---min-similarity.
-
-Output (stdout) format, one pair per line:
-
-    <path1>\t<path2>\t<similarity>
-
-All progress / diagnostic messages are written to stderr so that stdout remains a
-clean, machine-readable stream consumed by the C++ side.
-
-The embedding model is intentionally a single constant: swapping it for another
-sentence-transformers compatible model only requires editing MODEL_NAME below.
-"""
 
 import argparse
 import os
 import sys
 
-# Change this single constant to use a different embedding model.
 MODEL_NAME = "jinaai/jina-embeddings-v2-base-code"
 
-# Cap the token sequence length. jina-v2 accepts up to 8192 tokens, but attention
-# memory is O(seq_len^2): a single very long function body can otherwise try to
-# allocate tens of GB. 1024 tokens is enough to characterize a function for
-# similarity, and longer bodies are simply truncated.
+# Cap the token sequence length. jina-v2 accepts up to 8192 tokens, but 
+# a single very long function body can try to
+# allocate tens of GB. Longer bodies will be  truncated.
 DEFAULT_MAX_SEQ_LENGTH = 1024
 
 # Conservative batch size to keep peak memory bounded on large codebases.
@@ -71,8 +51,7 @@ def compute_embeddings(bodies, max_seq_length, batch_size, model_name):
 
     log(f"Embedding {len(bodies)} function bodies "
         f"(max_seq_length={max_seq_length}, batch_size={batch_size})...")
-    # Batched call; normalize so cosine similarity is a plain dot product. The
-    # progress bar goes to stderr, keeping stdout a clean machine-readable stream.
+
     embeddings = model.encode(
         bodies,
         normalize_embeddings=True,
@@ -83,8 +62,6 @@ def compute_embeddings(bodies, max_seq_length, batch_size, model_name):
 
 
 def emit_similar_pairs(file_paths, embeddings, min_similarity):
-    # Embeddings are already L2-normalized, so the cosine similarity matrix is
-    # just the Gram matrix.
     similarity_matrix = embeddings @ embeddings.T
     count = len(file_paths)
 
@@ -154,9 +131,6 @@ def main():
     bodies = read_function_bodies(file_paths)
     embeddings = compute_embeddings(bodies, args.max_seq_length, args.batch_size, args.model)
 
-    # Emit paths relative to the source dir (e.g. "file.c/function.c"). The query
-    # side treats each path as a resource path resolved against the source/info/
-    # header cache roots, so absolute paths would not resolve.
     relative_paths = [os.path.relpath(p, args.source_dir) for p in file_paths]
     emit_similar_pairs(relative_paths, embeddings, args.min_similarity)
     return 0

--- a/third-party/llm-detection/llm_detection.py
+++ b/third-party/llm-detection/llm_detection.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""LLM-embedding based code duplication detector for arkanjo.
+
+Reads every materialized function body under --source-dir, embeds each one with a
+Hugging Face model (jinaai/jina-embeddings-v2-base-code) through the
+sentence-transformers library, computes the pairwise cosine similarity scaled to
+a 0-100 range, and prints the pairs whose similarity is greater than or equal to
+--min-similarity.
+
+Output (stdout) format, one pair per line:
+
+    <path1>\t<path2>\t<similarity>
+
+All progress / diagnostic messages are written to stderr so that stdout remains a
+clean, machine-readable stream consumed by the C++ side.
+
+The embedding model is intentionally a single constant: swapping it for another
+sentence-transformers compatible model only requires editing MODEL_NAME below.
+"""
+
+import argparse
+import os
+import sys
+
+# Change this single constant to use a different embedding model.
+MODEL_NAME = "jinaai/jina-embeddings-v2-base-code"
+
+# Cap the token sequence length. jina-v2 accepts up to 8192 tokens, but attention
+# memory is O(seq_len^2): a single very long function body can otherwise try to
+# allocate tens of GB. 1024 tokens is enough to characterize a function for
+# similarity, and longer bodies are simply truncated.
+DEFAULT_MAX_SEQ_LENGTH = 1024
+
+# Conservative batch size to keep peak memory bounded on large codebases.
+DEFAULT_BATCH_SIZE = 4
+
+
+def log(message):
+    print(message, file=sys.stderr, flush=True)
+
+
+def find_function_files(source_dir):
+    """Recursively collect every regular file under source_dir (absolute paths)."""
+    file_paths = []
+    for root, _dirs, files in os.walk(source_dir):
+        for name in files:
+            file_paths.append(os.path.abspath(os.path.join(root, name)))
+    file_paths.sort()
+    return file_paths
+
+
+def read_function_bodies(file_paths):
+    bodies = []
+    for path in file_paths:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                bodies.append(handle.read())
+        except OSError as error:
+            log(f"Could not read {path}: {error}")
+            bodies.append("")
+    return bodies
+
+
+def compute_embeddings(bodies, max_seq_length, batch_size):
+    import numpy as np
+    from sentence_transformers import SentenceTransformer
+
+    log(f"Loading model {MODEL_NAME} (first run downloads weights)...")
+    model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
+    model.max_seq_length = max_seq_length
+
+    log(f"Embedding {len(bodies)} function bodies "
+        f"(max_seq_length={max_seq_length}, batch_size={batch_size})...")
+    # Batched call; normalize so cosine similarity is a plain dot product. The
+    # progress bar goes to stderr, keeping stdout a clean machine-readable stream.
+    embeddings = model.encode(
+        bodies,
+        normalize_embeddings=True,
+        batch_size=batch_size,
+        show_progress_bar=True,
+    )
+    return np.asarray(embeddings, dtype=np.float32)
+
+
+def emit_similar_pairs(file_paths, embeddings, min_similarity):
+    # Embeddings are already L2-normalized, so the cosine similarity matrix is
+    # just the Gram matrix.
+    similarity_matrix = embeddings @ embeddings.T
+    count = len(file_paths)
+
+    out = sys.stdout
+    for i in range(count):
+        for j in range(count):
+            if i == j:
+                continue
+            cosine = float(similarity_matrix[i][j])
+            # Clamp before scaling to guard against floating-point drift.
+            cosine = max(-1.0, min(1.0, cosine))
+            score = cosine * 100.0
+            if score >= min_similarity:
+                out.write(f"{file_paths[i]}\t{file_paths[j]}\t{score:.2f}\n")
+    out.flush()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="LLM-embedding code duplication detector for arkanjo."
+    )
+    parser.add_argument(
+        "--source-dir",
+        required=True,
+        help="Directory containing the materialized function bodies.",
+    )
+    parser.add_argument(
+        "--min-similarity",
+        type=float,
+        default=0.0,
+        help="Minimum similarity (0-100) for a pair to be reported.",
+    )
+    parser.add_argument(
+        "--max-seq-length",
+        type=int,
+        default=DEFAULT_MAX_SEQ_LENGTH,
+        help=(
+            "Maximum token sequence length per function body. Longer bodies are "
+            f"truncated. Attention memory scales as O(seq_len^2). Default: {DEFAULT_MAX_SEQ_LENGTH}."
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=DEFAULT_BATCH_SIZE,
+        help=(
+            "Number of function bodies embedded in parallel. Lower this on "
+            f"machines with less RAM. Default: {DEFAULT_BATCH_SIZE}."
+        ),
+    )
+    args = parser.parse_args()
+
+    file_paths = find_function_files(args.source_dir)
+    if len(file_paths) < 2:
+        log("Fewer than two function bodies found; nothing to compare.")
+        return 0
+
+    bodies = read_function_bodies(file_paths)
+    embeddings = compute_embeddings(bodies, args.max_seq_length, args.batch_size)
+
+    # Emit paths relative to the source dir (e.g. "file.c/function.c"). The query
+    # side treats each path as a resource path resolved against the source/info/
+    # header cache roots, so absolute paths would not resolve.
+    relative_paths = [os.path.relpath(p, args.source_dir) for p in file_paths]
+    emit_similar_pairs(relative_paths, embeddings, args.min_similarity)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/third-party/llm-detection/llm_detection.py
+++ b/third-party/llm-detection/llm_detection.py
@@ -67,9 +67,7 @@ def emit_similar_pairs(file_paths, embeddings, min_similarity):
 
     out = sys.stdout
     for i in range(count):
-        for j in range(count):
-            if i == j:
-                continue
+        for j in range(i + 1, count):
             cosine = float(similarity_matrix[i][j])
             # Clamp before scaling to guard against floating-point drift.
             cosine = max(-1.0, min(1.0, cosine))

--- a/third-party/llm-detection/requirements.txt
+++ b/third-party/llm-detection/requirements.txt
@@ -1,0 +1,6 @@
+sentence-transformers>=2.7
+# transformers 5.x removed symbols (e.g. find_pruneable_heads_and_indices) that
+# the jina-embeddings-v2 custom code relies on; pin to the 4.x series.
+transformers>=4.41,<5
+numpy>=1.24
+einops>=0.7


### PR DESCRIPTION
#2 
Adds a new duplication detection technique based on **code embeddings** (semantic similarity), available as the 4th duplication finder in the preprocessor. Also adds a **granularity** option to compare the codebase function-by-function (default) or file-by-file. Also includes a CMake build fix: links Threads::Threads into core_methods to resolve an undefined pthread reference during linking.

## How it works

Each function body is embedded with a Hugging Face model (default `jinaai/jina-embeddings-v2-base-code`) via a Python helper, then compared with pairwise cosine similarity (0–100). Same input/output as the other methods, so all query commands work unchanged.

## New CLI flags (optional, this method only)

| Flag | Purpose | Default |
| --- | --- | --- |
| `--llm-max-seq-length` | Max tokens per function body | `1024` |
| `--llm-batch-size` | Bodies embedded in parallel | `4` |
| `--llm-model` | Hugging Face embedding model | `jinaai/jina-embeddings-v2-base-code` |

## Usage

```sh
python3 -m pip install -r third-party/llm-detection/requirements.txt
arkanjo-preprocessor build [path] [--llm-max-seq-length N] [--llm-batch-size N] [--llm-model NAME]
# then pick option 4 and enter the minimum similarity
