### PR TITLE
feat: add cache cleanup command

### DIFF
--- a/src/commands/pre/clean/preprocessor_clean.cpp
+++ b/src/commands/pre/clean/preprocessor_clean.cpp
@@ -22,6 +22,7 @@ bool PreprocessorClean::run([[maybe_unused]] const ParsedOptions& options) {
             std::cout << "Cache directory does not exist, nothing to clean.\n";
         }
     } catch (const std::exception& e) {
+        // Use CLIError to ensure consistent error reporting across the CLI
         throw CLIError("Error while cleaning cache: " + std::string(e.what()));
     }
 

--- a/src/commands/pre/clean/preprocessor_clean.cpp
+++ b/src/commands/pre/clean/preprocessor_clean.cpp
@@ -1,12 +1,13 @@
 #include "preprocessor_clean.hpp"
 #include <arkanjo/base/config.hpp>
+#include <arkanjo/cli/cli_error.hpp>
 #include <filesystem>
 #include <iostream>
+#include <string> 
 
 namespace fs = std::filesystem;
 
 bool PreprocessorClean::validate([[maybe_unused]] const ParsedOptions& options) {
-
     return true;
 }
 
@@ -15,14 +16,13 @@ bool PreprocessorClean::run([[maybe_unused]] const ParsedOptions& options) {
         fs::path cache_dir = Config::config().base_path / Config::config().name_container;
 
         if (fs::exists(cache_dir)) {
-            fs::remove_all(cache_dir); 
+            fs::remove_all(cache_dir);
             std::cout << "Successfully cleaned cache directory: " << cache_dir.string() << "\n";
         } else {
             std::cout << "Cache directory does not exist, nothing to clean.\n";
         }
     } catch (const std::exception& e) {
-        std::cerr << "Error while cleaning cache: " << e.what() << "\n";
-        return false;
+        throw CLIError("Error while cleaning cache: " + std::string(e.what()));
     }
 
     return true;

--- a/src/commands/pre/clean/preprocessor_clean.cpp
+++ b/src/commands/pre/clean/preprocessor_clean.cpp
@@ -1,0 +1,29 @@
+#include "preprocessor_clean.hpp"
+#include <arkanjo/base/config.hpp>
+#include <filesystem>
+#include <iostream>
+
+namespace fs = std::filesystem;
+
+bool PreprocessorClean::validate([[maybe_unused]] const ParsedOptions& options) {
+
+    return true;
+}
+
+bool PreprocessorClean::run([[maybe_unused]] const ParsedOptions& options) {
+    try {
+        fs::path cache_dir = Config::config().base_path / Config::config().name_container;
+
+        if (fs::exists(cache_dir)) {
+            fs::remove_all(cache_dir); 
+            std::cout << "Successfully cleaned cache directory: " << cache_dir.string() << "\n";
+        } else {
+            std::cout << "Cache directory does not exist, nothing to clean.\n";
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "Error while cleaning cache: " << e.what() << "\n";
+        return false;
+    }
+
+    return true;
+}

--- a/src/commands/pre/clean/preprocessor_clean.hpp
+++ b/src/commands/pre/clean/preprocessor_clean.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <arkanjo/commands/command.hpp>
+
+class PreprocessorClean : public ICommand {
+  public:
+    PreprocessorClean() = default;
+    ~PreprocessorClean() override = default;
+
+    bool validate(const ParsedOptions& options) override;
+    bool run(const ParsedOptions& options) override;
+};

--- a/src/commands/pre/clean/preprocessor_clean.hpp
+++ b/src/commands/pre/clean/preprocessor_clean.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
-#include <arkanjo/commands/command.hpp>
+#include <arkanjo/cli/command_base.hpp>
+#include <arkanjo/cli/parsed_options.hpp>
 
-class PreprocessorClean : public ICommand {
-  public:
+class PreprocessorClean : public CommandBase<PreprocessorClean> {
+public:
     PreprocessorClean() = default;
-    ~PreprocessorClean() override = default;
+
+    COMMAND_DESCRIPTION("Removes the application cache directory.")
 
     bool validate(const ParsedOptions& options) override;
     bool run(const ParsedOptions& options) override;

--- a/src/commands/pre/preprocessor_main.cpp
+++ b/src/commands/pre/preprocessor_main.cpp
@@ -1,19 +1,18 @@
 // As preprocessor is, in the moment, separated from orchestrator
 // we define a main function to use it.
-
-#include "build/preprocessor_build.hpp"
-#include "list/preprocessor_list.hpp"
 #include "../help/help.hpp"
+#include "build/preprocessor_build.hpp"
+#include "clean/preprocessor_clean.hpp"
+#include "list/preprocessor_list.hpp"
+#include <arkanjo/commands/command.hpp>
+#include <arkanjo/formatter/format_manager.hpp>
+#include <arkanjo/orchestrator.hpp>
+#include <arkanjo/orchestrator_helper.hpp>
 #include <cassert>
 #include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <string>
-
-#include <arkanjo/orchestrator_helper.hpp>
-#include <arkanjo/orchestrator.hpp>
-#include <arkanjo/commands/command.hpp>
-#include <arkanjo/formatter/format_manager.hpp>
 
 int main(int argc, char* argv[]) {
     auto& cfg = Config::config();
@@ -24,14 +23,14 @@ int main(int argc, char* argv[]) {
     Context ctx;
 
     ctx.command_name = (argc > 1) ? argv[1] : OrchestratorHelper::DEFAULT_COMMAND;
-    
+
     ctx.argc = argc;
     ctx.argv = argv;
 
     static const std::vector<std::pair<std::vector<std::string>, CommandsRegistry::CommandFactory>> internal_commands = {
         {{"build"}, [&]() { return std::make_unique<PreprocessorBuild>(); }},
-        {{"list", "ls"}, [&]() { return std::make_unique<PreprocessorList>(); }}
-    };
+        {{"list", "ls"}, [&]() { return std::make_unique<PreprocessorList>(); }},
+        {{"clean"}, [&]() { return std::make_unique<PreprocessorClean>(); }}};
 
     std::unique_ptr<ICommand> command;
     orchestrator.add_step(OrchestratorHelper::setup_command_step(command, internal_commands));


### PR DESCRIPTION
Implements the clean command to remove cached preprocessor profiles, as requested in issue #23.