### PR TITLE
feat(preprocessor): implement --all option for clean command (#31)

### DIFF
--- a/src/commands/pre/clean/preprocessor_clean.cpp
+++ b/src/commands/pre/clean/preprocessor_clean.cpp
@@ -8,18 +8,26 @@
 namespace fs = std::filesystem;
 
 bool PreprocessorClean::validate(const ParsedOptions& options) {
+    clean_all = options.args.count("all") > 0;
     return true;
 }
 
 bool PreprocessorClean::run(const ParsedOptions& options) {
     try {
-        fs::path cache_dir = Config::config().base_path / Config::config().name_container;
+        fs::path base_path = Config::config().base_path;
+        fs::path cache_dir = clean_all ? base_path : base_path / Config::config().name_container;
+
         if (fs::exists(cache_dir)) {
             fs::remove_all(cache_dir);
-            std::cout << "Successfully cleaned cache directory: " << cache_dir.string() << "\n";
-        } else {
-            std::cout << "Cache directory does not exist, nothing to clean.\n";
-        }
+            fs::create_directories(base_path);
+
+            if (clean_all) {
+                std::cout << "Successfully cleaned all cache directories in: " << cache_dir.string() << "\n";
+            } 
+            else std::cout << "Successfully cleaned cache directory: " << cache_dir.string() << "\n";
+        } 
+        else std::cout << "Cache directory does not exist, nothing to clean.\n";
+
     } catch (const std::exception& e) {
         throw CLIError("Error while cleaning cache: " + std::string(e.what()));
     }

--- a/src/commands/pre/clean/preprocessor_clean.hpp
+++ b/src/commands/pre/clean/preprocessor_clean.hpp
@@ -11,7 +11,15 @@
 #include <arkanjo/commands/command_base.hpp>
 
 class PreprocessorClean : public CommandBase<PreprocessorClean> {
+
+    bool clean_all = false;
+
 public:
+    static constexpr CliOption options_[] = {
+        {"all", 0, NoArgument, "Remove all cached preprocess profiles."},
+        OPTION_END
+    };
+    
     PreprocessorClean() = default;
 
     COMMAND_DESCRIPTION("Removes the application cache directory.")


### PR DESCRIPTION
Add --all option in the clean command to remove all cached preprocess profiles.

Obs: We tried to follow the code pattern found in preprocessor_build.cpp/.h 
Obs2: This contribution attempt is part of the phase 2 of the MAC0470 course.

Signed-off-by: Andre Luiz Batista Bueno <andrebatistabueno@gmail.com>
Co-authored-by: Enzo Furegatti Spinella <enzo.spinella@usp.br>