### PR TITLE
fix(methods): store relative paths in output_parsed.txt

### DIFF
--- a/src/methods/diff/diff_method.cpp
+++ b/src/methods/diff/diff_method.cpp
@@ -159,6 +159,11 @@ void DiffMethod::execute() {
 
     std::vector<DuplicationEntry> file_duplication_pairs = find_similar_pairs(file_paths);
 
+    for (auto& [sim, path1, path2] : file_duplication_pairs) {
+        path1 = fs::relative(path1, base).string();
+        path2 = fs::relative(path2, base).string();
+    }
+
     fm::write(SAVING_MESSAGE);
 
     save_duplications(file_duplication_pairs);


### PR DESCRIPTION
DiffMethod was saving absolute file paths into output_parsed.txt. When the query stage (explorer, finder, counter) loaded those paths into Path objects, Path::build_info_path() composed the final path with fs::path::operator/, which silently discards the left-hand prefix whenever the right-hand operand is absolute. Consequently, the info JSON lookup resolved to a path inside features/source/ instead of the info/ directory, raising a file-not-found error at startup.

ASTMethod was not affected because it derives paths from FunctionData::path, which is already relative to the source feature directory. In DiffMethod::execute() the absolute paths come from fs::recursive_directory_iterator, which yields absolute entries when the search root is absolute.

Relativize both path components in DiffMethod::execute() using fs::relative() against the respective source directory, immediately after similarity computation and before the call to save_duplications().  This keeps the fix self-contained in the execute() functions and leaves find_files() and read_results() unchanged, as they still need absolute paths for file I/O.

---

**How to reproduce:**

```bash
# Preprocess the test codebase with DiffMethod
echo -e "tests/e2e/codebase\n0.9\n2" | ./build/arkanjo-preprocessor build

# Run any query command
./build/arkanjo explorer
```

**Before this fix:**
```bash
Unexpected error: Attempted to open file: ~/.cache/arkanjo/default/features/source/test_same_file_similar_functions.c/sorted_by_distance_to_median.json but an Error ocurred. Check if the file exist.
```

**After this fix:** explorer runs correctly.