### PR TITLE
feat(explorer): add --template-help flag for template variable discoverability

### DIFF
--- a/src/commands/explorer/similarity_explorer.cpp
+++ b/src/commands/explorer/similarity_explorer.cpp
@@ -5,7 +5,6 @@ The code filter every file that has the pattern as a substring, so be carefull w
 */
 
 #include <algorithm>
-#include <iostream>
 #include <utility>
 
 #include <arkanjo/formatter/format_manager.hpp>
@@ -192,24 +191,18 @@ bool SimilarityExplorer::validate(const ParsedOptions& options) {
 }
 
 void SimilarityExplorer::print_template_variables() {
-    std::cout << "Template variables for --template:\n\n";
-    std::cout << "  {path_a}           Relative path and function name, e.g. src/dir::my_func\n";
-    std::cout << "  {path_b}           Relative path and function name for function B\n";
-    std::cout << "  {dir_a}            Parent directory of function A's file\n";
-    std::cout << "  {dir_b}            Parent directory of function B's file\n";
-    std::cout << "  {filename_a}       Filename of function A\n";
-    std::cout << "  {filename_b}       Filename of function B\n";
-    std::cout << "  {func_a}           Function name A\n";
-    std::cout << "  {func_b}           Function name B\n";
-    std::cout << "  {start_a}          Start line of function A\n";
-    std::cout << "  {start_b}          Start line of function B\n";
-    std::cout << "  {end_a}            End line of function A\n";
-    std::cout << "  {end_b}            End line of function B\n";
-    std::cout << "  {duplicated_lines} Line count of the duplicate\n";
-    std::cout << "\nStyle modifiers (append as {variable:modifier}):\n\n";
-    std::cout << "  file, function, number, bold, warning, row_even, row_odd\n";
-    std::cout << "\nExample:\n";
-    std::cout << "  arkanjo explorer --template \"{func_a:function} ~ {func_b:function} ({duplicated_lines:number} lines)\"\n";
+    SimilarityExplorerEntry entry = {};
+    json j;
+    to_json(j, entry);
+
+    fm::write(BOLD("Available variables for --template:"));
+    for (const auto& [k, _] : j.items()) {
+        fm::write("  {" + k + "}");
+    }
+
+    fm::write("");
+    fm::write(BOLD("Example:"));
+    fm::write("  arkanjo explorer --template \"{func_a:function} ~ {func_b:function} ({duplicated_lines:number} lines)\"\n");
 }
 
 bool SimilarityExplorer::run(const ParsedOptions& options) {

--- a/src/commands/explorer/similarity_explorer.cpp
+++ b/src/commands/explorer/similarity_explorer.cpp
@@ -191,7 +191,33 @@ bool SimilarityExplorer::validate(const ParsedOptions& options) {
     return true;
 }
 
+void SimilarityExplorer::print_template_variables() {
+    std::cout << "Template variables for --template:\n\n";
+    std::cout << "  {path_a}           Relative path and function name, e.g. src/dir::my_func\n";
+    std::cout << "  {path_b}           Relative path and function name for function B\n";
+    std::cout << "  {dir_a}            Parent directory of function A's file\n";
+    std::cout << "  {dir_b}            Parent directory of function B's file\n";
+    std::cout << "  {filename_a}       Filename of function A\n";
+    std::cout << "  {filename_b}       Filename of function B\n";
+    std::cout << "  {func_a}           Function name A\n";
+    std::cout << "  {func_b}           Function name B\n";
+    std::cout << "  {start_a}          Start line of function A\n";
+    std::cout << "  {start_b}          Start line of function B\n";
+    std::cout << "  {end_a}            End line of function A\n";
+    std::cout << "  {end_b}            End line of function B\n";
+    std::cout << "  {duplicated_lines} Line count of the duplicate\n";
+    std::cout << "\nStyle modifiers (append as {variable:modifier}):\n\n";
+    std::cout << "  file, function, number, bold, warning, row_even, row_odd\n";
+    std::cout << "\nExample:\n";
+    std::cout << "  arkanjo explorer --template \"{func_a:function} ~ {func_b:function} ({duplicated_lines:number} lines)\"\n";
+}
+
 bool SimilarityExplorer::run(const ParsedOptions& options) {
+    if (options.args.count("template-help")) {
+        print_template_variables();
+        return true;
+    }
+
     auto it_pattern = options.args.find("pattern");
     if (it_pattern != options.args.end()) {
         pattern_to_match = it_pattern->second;

--- a/src/commands/explorer/similarity_explorer.hpp
+++ b/src/commands/explorer/similarity_explorer.hpp
@@ -43,7 +43,8 @@ class SimilarityExplorer : public CommandBase<SimilarityExplorer> {
         {"sort", 's', NoArgument, "Sort results by number of duplicated lines. By default, results are sorted by the similarity metric."},
         {"cluster", 'c', NoArgument, "Print results with cluster relationships from the similarity table."},
         {"verbose", 0, NoArgument, "Enable verbose output"},
-        {"template", 't', RequiredArgument, "Output format template used to render each result entry."},
+        {"template", 't', RequiredArgument, "Output format template for each result entry. Run --template-help to see available variables and an example."},
+        {"template-help", 0, NoArgument, "Show available template variables and style modifiers for --template."},
         OPTION_END
     };
     COMMAND_DESCRIPTION(
@@ -128,6 +129,11 @@ class SimilarityExplorer : public CommandBase<SimilarityExplorer> {
      * @return vector<SimilarPair> Filtered and sorted pairs
      */
     std::vector<SimilarPair> build_similar_path_pairs();
+
+    /**
+     * @brief Prints all available template variables and style modifiers to stdout.
+     */
+    static void print_template_variables();
 
     /**
      * @brief Display clusters of similar functions.

--- a/src/commands/explorer/similarity_explorer.hpp
+++ b/src/commands/explorer/similarity_explorer.hpp
@@ -44,7 +44,7 @@ class SimilarityExplorer : public CommandBase<SimilarityExplorer> {
         {"cluster", 'c', NoArgument, "Print results with cluster relationships from the similarity table."},
         {"verbose", 0, NoArgument, "Enable verbose output"},
         {"template", 't', RequiredArgument, "Output format template for each result entry. Run --template-help to see available variables and an example."},
-        {"template-help", 0, NoArgument, "Show available template variables and style modifiers for --template."},
+        {"template-help", 0, NoArgument, "Show available template variables for --template."},
         OPTION_END
     };
     COMMAND_DESCRIPTION(
@@ -131,7 +131,7 @@ class SimilarityExplorer : public CommandBase<SimilarityExplorer> {
     std::vector<SimilarPair> build_similar_path_pairs();
 
     /**
-     * @brief Prints all available template variables and style modifiers to stdout.
+     * @brief Prints all available template variables for --template.
      */
     static void print_template_variables();
 


### PR DESCRIPTION
Users of `--template` had no way to discover available `{variable}` names and style modifiers without reading source code. `--template-help` prints the full reference and an example, and exits before loading the similarity cache — so it works even without a preprocessed codebase, mirroring the `--help` pattern. Closes #33 

---

**How to verify:**

```bash
arkanjo explorer --template-help
```