### PR TITLE
Add Args for arkanjo-preprocessor: minimum similarity + method

### DIFF
--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -32,9 +32,18 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
     }
     fs::path path(path_str);
 
-    fm::write(MINIMUM_SIMILARITY_MESSAGE);
-    std::cin >> similarity_message;
-    double similarity = stod(similarity_message);
+    double similarity = 0.0;
+    if (options) {
+        auto it = options->args.find("similarity");
+        if (it != options->args.end() && !it->second.empty()) {
+            similarity = std::stod(it->second);
+        }
+    }
+    if (similarity == 0.0) {
+        fm::write(MINIMUM_SIMILARITY_MESSAGE);
+        std::cin >> similarity_message;
+        similarity = stod(similarity_message);
+    }
 
     size_t use_duplication_finder_index = 0;
 

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -1,6 +1,7 @@
 #include "preprocessor_build.hpp"
 #include <cassert>
 #include <iostream>
+#include <algorithm>
 #include <optional>
 
 #include <arkanjo/base/config.hpp>
@@ -46,24 +47,50 @@ PreprocessorBuild::read_parameters(const std::optional<ParsedOptions>& options) 
     }
 
     size_t use_duplication_finder_index = 0;
+    bool method_from_option = false;
 
-    while (true) {
-        fm::write(MESSAGE_DUPLICATION_FINDER_TYPE);
-        for (size_t i = 0; i < MethodsType.size(); ++i) {
-            std::cout << i + 1 << ") " << MethodsType[i].description << '\n';
+    if (options) {
+        auto it = options->args.find("method");
+        if (it != options->args.end() && !it->second.empty()) {
+            const auto& val = it->second;
+            auto found = std::find_if(MethodsType.begin(), MethodsType.end(),
+                [&val](const MethodInfo& mi) {
+                    return std::to_string(mi.id) == val || mi.name == val;
+                });
+            if (found == MethodsType.end()) {
+                std::string valid_methods;
+                for (size_t i = 0; i < MethodsType.size(); ++i) {
+                    if (i > 0) valid_methods += ", ";
+                    valid_methods += std::to_string(MethodsType[i].id);
+                    valid_methods += "|";
+                    valid_methods += MethodsType[i].name;
+                }
+                throw CLIError(
+                    "Invalid --method value: '" + val +
+                    "'. Use " + valid_methods + ".");
+            }
+            use_duplication_finder_index = found->id - 1;
+            method_from_option = true;
         }
-
-        std::cin >> use_duplication_finder_index;
-
-        if (
-            use_duplication_finder_index == 0 ||
-            use_duplication_finder_index > MethodsType.size()
-        ) {
-            throw CLIError(INVALID_CODE_DUPLICATION_FINDER);
-        }
-        break;
     }
-    --use_duplication_finder_index;
+
+    if (!method_from_option) {
+        while (true) {
+            fm::write(MESSAGE_DUPLICATION_FINDER_TYPE);
+            for (size_t i = 0; i < MethodsType.size(); ++i) {
+                std::cout << i + 1 << ") " << MethodsType[i].description << '\n';
+            }
+            std::cin >> use_duplication_finder_index;
+            if (
+                use_duplication_finder_index == 0 ||
+                use_duplication_finder_index > MethodsType.size()
+            ) {
+                throw CLIError(INVALID_CODE_DUPLICATION_FINDER);
+            }
+            break;
+        }
+        --use_duplication_finder_index;
+    }
 
     std::vector<std::string> pass_through_args;
     Granularity granularity = Granularity::Function;

--- a/src/commands/pre/build/preprocessor_build.hpp
+++ b/src/commands/pre/build/preprocessor_build.hpp
@@ -32,6 +32,8 @@ using MethodFactory = std::function<std::unique_ptr<IMethod>(
 )>;
 
 struct MethodInfo {
+  size_t id;
+  std::string_view name;
   MethodFactory create;
   std::string_view description;
 };
@@ -74,6 +76,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
 
     const std::vector<MethodInfo> MethodsType = {
       {
+        1,
+        "gensim",
         [](const std::string& base_path, float similarity,
            const std::vector<std::string>&) {
           return std::make_unique<ToolMethod>(base_path, similarity);
@@ -81,6 +85,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
         "NLP text similarity using gensim"
       },
       {
+        2,
+        "diff",
         [](const std::string& base_path, float similarity,
            const std::vector<std::string>&) {
           return std::make_unique<DiffMethod>(base_path, similarity);
@@ -88,6 +94,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
         "Count proportion of equal lines using diff command"
       },
       {
+        3,
+        "tree-sitter",
         [](const std::string& base_path, float similarity,
            const std::vector<std::string>&) {
           return std::make_unique<ASTMethod>(base_path, similarity);
@@ -95,6 +103,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
         "Compare linearized structural sequences extracted from Tree-sitter ASTs"
       },
       {
+        4,
+        "language-model",
         [](const std::string& base_path, float similarity,
            const std::vector<std::string>& pass_through_args) {
           return std::make_unique<LLMMethod>(base_path, similarity, pass_through_args);
@@ -137,6 +147,8 @@ class PreprocessorBuild : public Preprocessor, public CommandBase<PreprocessorBu
         "Comparison granularity: 'function' (default) compares individual "
         "functions; 'file' keeps each file whole and compares files against "
         "each other. Applies to every duplication finder method."},
+      {"method", 0, RequiredArgument,
+        "Duplication finder method: 1|gensim, 2|diff, 3|tree-sitter, 4|language-model."},
       OPTION_END
     };
     PreprocessorBuild();


### PR DESCRIPTION
This allows running the preprocessor completely from CLI, without using the interactive mode. 

Usage example:
```bash
./arkanjo-preprocessor build -S 80 --method 3 -n staging --path $PATH
```
Th `-S` is used to fill the minimum-similarity.
The `--method` can be used with numbers of name.
In the case above, --method 3 ~= --method tree-sitter

The changes are also reflected in the --help:
```bash
./arkanjo-preprocessor build --help
Creates the foundation for fast query responses during the main operation phase.

Usage: arkanjo-preprocessor build [OPTIONS]...

Options:
      --color           Enable colored output.

      --granularity <GRANULARITY> Comparison granularity: 'function' (default) compares
                          individual functions; 'file' keeps each file whole and
                          compares files against each other. Applies to every
                          duplication finder method.

  -h, --help            Show this help message.

      --json            Json output.

      --method <METHOD> Duplication finder method: 1|gensim, 2|diff,
                          3|tree-sitter, 4|language-model.

      --minimum-lines <MINIMUM-LINES> Minimum clone size in original lines.

  -n, --name <NAME>     Assign a name to the cache container; defaults to
                          'default' if not provided.

      --no-color        Disable colored output.

      --path <PATH>     Project path to preprocess.

      --preprocessor    Forces the preprocessor to execute.

  -S, --similarity <SIMILARITY> Changes the similarity threshold to `SIMILARITY` for
                          the current command only.

      --verbose         Enable verbose output
```