### PR TITLE
fix(parser): prevent tree-sitter from leaking out-of-scope function n…

### DIFF
--- a/include/arkanjo/parser/tree_sitter_parser.hpp
+++ b/include/arkanjo/parser/tree_sitter_parser.hpp
@@ -11,6 +11,10 @@
 
 namespace fs = std::filesystem;
 
+struct SkipStats {
+  size_t errors;
+};
+
 class TreeSitterParser {
     static bool is_function_empty(TSNode body);
     
@@ -32,10 +36,23 @@ class TreeSitterParser {
 
     static TSNode get_body(TSNode node);
 
+    /**
+     * Returns whether a Tree-sitter subtree should be ignored due to parser errors.
+     *
+     * The decision is based on the number and density of ERROR nodes in the
+     * subtree, helping discard regions where the parser has likely lost
+     * synchronization.
+     *
+     * @param node Root of the subtree to inspect.
+     * @return True if the subtree should be ignored.
+     */
+    static bool should_ignore(TSNode node);
+
     static void collect_functions(
         TSNode node, const std::string& source, const fs::path& relative_path,
         const std::shared_ptr<TSTree>& tree,
-        std::function<void(const FunctionData&)> callback);
+        std::function<void(const FunctionData&)> callback,
+        SkipStats& stats);
 
     static std::shared_ptr<TSTree> parse_source(
         const fs::path& file_path, const std::string& source_code);
@@ -43,11 +60,13 @@ class TreeSitterParser {
   public:
     static void process_file(
       const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
-      std::function<void(const FunctionData&)> callback);
+      std::function<void(const FunctionData&)> callback,
+      SkipStats& stats);
 
     static void process_file_as_unit(
       const fs::path& file_path, const fs::path& relative_path, const std::string& source_code,
-      std::function<void(const FunctionData&)> callback);
+      std::function<void(const FunctionData&)> callback,
+      SkipStats& stats);
 
     explicit TreeSitterParser() = default;
 };

--- a/src/commands/pre/build/function_breaker.cpp
+++ b/src/commands/pre/build/function_breaker.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <unordered_map>
 #include <arkanjo/utils/utils.hpp>
-#include <arkanjo/parser/tree_sitter_parser.hpp>
 #include <arkanjo/base/config.hpp>
 #include <arkanjo/base/features/source_feature.hpp>
 #include <arkanjo/base/features/ast_feature.hpp>
@@ -60,6 +59,7 @@ std::string FunctionBreaker::create_info_json(
 void FunctionBreaker::file_breaker(
     const fs::path& file_path, const fs::path& folder_path,
     std::function<void(const FunctionData&)> on_function,
+    SkipStats& stats,
     Granularity granularity,
     int minimum_lines
 ) {
@@ -94,9 +94,9 @@ void FunctionBreaker::file_breaker(
     };
 
     if (granularity == Granularity::File) {
-        TreeSitterParser::process_file_as_unit(file_path, relative_path, source_code, handle_unit);
+        TreeSitterParser::process_file_as_unit(file_path, relative_path, source_code, handle_unit, stats);
     } else {
-        TreeSitterParser::process_file(file_path, relative_path, source_code, handle_unit);
+        TreeSitterParser::process_file(file_path, relative_path, source_code, handle_unit, stats);
     }
 }
 
@@ -104,6 +104,7 @@ void FunctionBreaker::file_breaker(
 int FunctionBreaker::process(
     const fs::path& folder_path,
     std::function<void(const FunctionData&)> on_function,
+    SkipStats& stats,
     int minimum_lines,
     Granularity granularity
 ) {
@@ -113,7 +114,7 @@ int FunctionBreaker::process(
         if (!dirEntry.is_regular_file()) continue;
 
         auto path = dirEntry.path();
-        file_breaker(path, folder_path, on_function, granularity, minimum_lines);
+        file_breaker(path, folder_path, on_function, stats, granularity, minimum_lines);
 
         size_files++;
     }

--- a/src/commands/pre/build/function_breaker.hpp
+++ b/src/commands/pre/build/function_breaker.hpp
@@ -24,6 +24,7 @@
 #include <tree_sitter/api.h>
 
 #include <arkanjo/base/function/function_data.hpp>
+#include <arkanjo/parser/tree_sitter_parser.hpp>
 
 namespace fs = std::filesystem;
 
@@ -100,6 +101,7 @@ class FunctionBreaker {
     void file_breaker(
       const fs::path& file_path, const fs::path& folder_path,
       std::function<void(const FunctionData&)> on_function,
+      SkipStats& stats,
       Granularity granularity = Granularity::Function,
       int minimum_lines = 0);
 
@@ -113,6 +115,7 @@ class FunctionBreaker {
     int process(
       const fs::path& folder_path,
       std::function<void(const FunctionData&)> on_function,
+      SkipStats& stats,
       int minimum_lines = 0,
       Granularity granularity = Granularity::Function);
 

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -133,13 +133,16 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
     auto method = MethodsType[use_duplication_finder_index].create(
         base_path, similarity, pass_through_args);
 
+    SkipStats stats = {};
+
     FunctionBreaker function_breaker;
     auto size_files = function_breaker.process(path, [&method](const FunctionData& fd) {
         method->on_function(fd);
-    }, minimum_lines, granularity);
+    }, stats, minimum_lines, granularity);
 
     if (mode_verbose) {
         fm::write("\tFound " + std::to_string(size_files) + " files");
+        fm::write("\tSkipped " + std::to_string(stats.errors) +" parser errors");
         fm::time("\tExecution time breaker:", start_breaker);
     }
 

--- a/src/parser/tree_sitter_parser.cpp
+++ b/src/parser/tree_sitter_parser.cpp
@@ -98,17 +98,48 @@ TSNode TreeSitterParser::get_body(TSNode node) {
     return TSNode{};
 }
 
+bool TreeSitterParser::should_ignore(TSNode node) {
+    size_t errors = 0;
+    size_t size = 0;
+
+    std::function<void(TSNode)> dfs = [&](TSNode n) {
+        size++;
+
+        if (ts_node_is_error(n))
+            errors++;
+
+        uint32_t child_count = ts_node_child_count(n);
+        for (uint32_t i = 0; i < child_count; i++)
+            dfs(ts_node_child(n, i));
+    };
+
+    dfs(node);
+
+    if (size == 0) return false;
+
+    double ratio = static_cast<double>(errors) / static_cast<double>(size);
+    int threshold = 1 + static_cast<int>(std::log2(size));
+
+    return (errors > threshold) || (ratio > 0.1);
+}
+
 void TreeSitterParser::collect_functions(
     TSNode node, 
     const std::string& source, 
     const fs::path& relative_path,
     const std::shared_ptr<TSTree>& tree,
-    std::function<void(const FunctionData&)> callback
+    std::function<void(const FunctionData&)> callback,
+    SkipStats& stats
 ) {
     std::string_view type = ts_node_type(node);
     if (FeatureExtractor::is_function_node(type)) {
         TSPoint start = ts_node_start_point(node);
         TSPoint end = ts_node_end_point(node);
+
+        if (TreeSitterParser::should_ignore(node)) {
+            stats.errors++;
+            return;
+        }
 
         TSNode body = get_body(node);
 
@@ -154,7 +185,8 @@ void TreeSitterParser::collect_functions(
             source,
             relative_path,
             tree,
-            callback
+            callback,
+            stats
         );
     }
 }
@@ -202,14 +234,15 @@ void TreeSitterParser::process_file(
     const fs::path& file_path,
     const fs::path& relative_path,
     const std::string& source_code,
-    std::function<void(const FunctionData&)> callback
+    std::function<void(const FunctionData&)> callback,
+    SkipStats& stats
 ) {
     std::shared_ptr<TSTree> tree = parse_source(file_path, source_code);
     if (!tree) return;
 
     TSNode root_node = ts_tree_root_node(tree.get());
 
-    collect_functions(root_node, source_code, relative_path, tree, callback);
+    collect_functions(root_node, source_code, relative_path, tree, callback, stats);
 
     tree.reset();
 }
@@ -218,7 +251,8 @@ void TreeSitterParser::process_file_as_unit(
     const fs::path& file_path,
     const fs::path& relative_path,
     const std::string& source_code,
-    std::function<void(const FunctionData&)> callback
+    std::function<void(const FunctionData&)> callback,
+    SkipStats& stats
 ) {
     std::shared_ptr<TSTree> tree = parse_source(file_path, source_code);
     if (!tree) return;


### PR DESCRIPTION
Tree-sitter may lose synchronization when parsing some Linux kernel constructs, especially those involving macros and preprocessor directives.

Examples include:

```cpp
void __printf(3, 4) __cold
              ^^^^ Attribute-like macros.
```

```cpp
#define fscrypt_warn(inode, fmt, ...) \
                            ^^^^^^^^ Variadic macros and token pasting.
```

```cpp
void __init fsverity_init_info_cache(void);
     ^^^^^^ Compiler-specific attribute macros.
```

```cpp
extra = max_t(unsigned long, bss_len + stack_len,
                       ^^^^ Macros that accept C types as arguments.
```

```cpp
#ifdef CONFIG_64BIT
    [ilog2(VM_SEALED)] = "sl",
    ^^^^^^^^^^^^^^^^^^^ Conditional compilation may leave the parser with incomplete syntax.
#endif
```

Because a single parsing error often propagates to the rest of the subtree, `should_ignore()` estimates how contaminated a subtree is instead of checking only for the existence of an `ERROR` node.

<details>
<summary>To visualize where Tree-sitter reports `ERROR` nodes, I used the following helper (inside `if (should_ignore(node))`):</summary>

```cpp
std::vector<std::pair<uint32_t, uint32_t>> errors;

std::function<void(TSNode)> dfs = [&](TSNode n) {

    if (ts_node_is_error(n)) {
        uint32_t s = ts_node_start_byte(n);
        uint32_t e = ts_node_end_byte(n);
        errors.push_back({s, e});
    }

    uint32_t child_count = ts_node_child_count(n);
    for (uint32_t i = 0; i < child_count; i++)
        dfs(ts_node_child(n, i));
};

dfs(node);

std::sort(errors.begin(), errors.end());

uint32_t start = ts_node_start_byte(node);
uint32_t end   = ts_node_end_byte(node);

size_t i = start;

for (auto &[s, e] : errors) {

    if (e <= start || s >= end)
        continue;

    if (i < s)
        std::cout << source.substr(i, s - i);

    uint32_t hs = std::max(s, start);
    uint32_t he = std::min(e, end);

    std::cout << "\033[0;35m"
            << source.substr(hs, he - hs)
            << "\033[0m";

    i = he;
}

if (i < end)
    std::cout << source.substr(i, end - i);
```
</details>

### Reproduce

To reproduce the parser failures, I used the `fs` subsystem from the Linux kernel:

```bash
arkanjo preprocessor build \
  --name fs_testing \
  --path linux/fs \
  -S 80.0 \
  --method tree-sitter \
  --verbose
```

```text
Found 2286 files
Found 12 parser errors
Execution time breaker: 00:00:21.149
```

Some of these failures are shown above.