### PR TITLE
docs: document CLI orchestration headers

### DIFF
--- a/include/arkanjo/base/function/function.hpp
+++ b/include/arkanjo/base/function/function.hpp
@@ -72,6 +72,9 @@ class Function {
      */
     explicit Function(const Path& _path);
 
+    /**
+     * @brief Loads source, header, and metadata for this function.
+     */
     void load();
 
     /**
@@ -100,5 +103,9 @@ class Function {
      */
     void print_basic_info();
 
+    /**
+     * @brief Prints the function source code to the console.
+     * @param no_numbers When true, omits line numbers from the output.
+     */
     void print_code(bool no_numbers = false);
 };

--- a/include/arkanjo/cli/options_collector.hpp
+++ b/include/arkanjo/cli/options_collector.hpp
@@ -5,11 +5,21 @@
 #include <string>
 #include <vector>
 
+/**
+ * @brief Collects CLI option definitions before parsing a command.
+ *
+ * The collector merges global and command-specific options into a single list
+ * that can be passed to the parser step in the orchestrator pipeline.
+ */
 class OptionsCollector {
   private:
-    std::vector<struct CliOption> merged_long_opts;
+    std::vector<struct CliOption> merged_long_opts; ///< Merged option definitions.
 
   public:
+    /**
+     * @brief Appends a null-terminated option array to the merged options.
+     * @param long_opts Pointer to a `CliOption` array terminated by `OPTION_END`.
+     */
     void add_options(const CliOption* long_opts) {
         if (long_opts != nullptr) {
             for (const CliOption* opt = long_opts; opt->long_name != nullptr; ++opt) {
@@ -18,6 +28,12 @@ class OptionsCollector {
         }
     }
 
+    /**
+     * @brief Builds an orchestrator step that parses CLI arguments.
+     * @param argc Number of process arguments.
+     * @param argv Raw process argument vector.
+     * @return Step that fills `Context::options` with parsed values.
+     */
     Step make_parse_step(int argc, char* argv[]) {
         return [=](Context& ctx) {
             merged_long_opts.push_back(OPTION_END);
@@ -29,6 +45,10 @@ class OptionsCollector {
         };
     }
 
+    /**
+     * @brief Returns the merged option definitions.
+     * @return Reference to the collected options.
+     */
     const std::vector<CliOption>& get_options() const {
         return merged_long_opts;
     }

--- a/include/arkanjo/commands/command_base.hpp
+++ b/include/arkanjo/commands/command_base.hpp
@@ -6,22 +6,42 @@
 #include <arkanjo/base/config.hpp>
 #include <algorithm> 
 
+/**
+ * @brief Declares the command description override for a command class.
+ */
 #define COMMAND_DESCRIPTION(str)                       \
     std::string_view description() const override {    \
         static constexpr char description_str[] = str; \
         return description_str;                        \
     }
 
+/**
+ * @brief Detects whether a command type declares an `options_` member.
+ */
 template <typename, typename = std::void_t<>>
 struct has_options : std::false_type {};
 
+/**
+ * @brief Specialization used when the command type provides CLI options.
+ */
 template <typename T>
 struct has_options<T, std::void_t<decltype(T::options_)>> : std::true_type {};
 
+/**
+ * @brief Base implementation shared by CLI commands.
+ *
+ * The base class provides option discovery, help rendering, and help-aware
+ * command execution while leaving command-specific behavior to `Derived::run`.
+ */
 template <typename Derived>
 class CommandBase : public ICommand {
 
   public:
+    /**
+     * @brief Prints formatted help text for a command.
+     * @param command_name Name or alias used to invoke the command.
+     * @param collector Optional collector containing merged global and command options.
+     */
     virtual void print_help(const std::string command_name, const OptionsCollector* collector) const {
         constexpr int OPTION_WIDTH = 26;
 
@@ -94,6 +114,10 @@ class CommandBase : public ICommand {
         }
     }
 
+    /**
+     * @brief Returns the command-specific option definitions.
+     * @return Pointer to a null-terminated `CliOption` array, or `nullptr` when absent.
+     */
     const CliOption* options() const final {
         if constexpr (has_options<Derived>::value) {
             return Derived::options_;
@@ -102,6 +126,13 @@ class CommandBase : public ICommand {
         }
     }
 
+    /**
+     * @brief Runs the command or displays help when requested.
+     * @param command_name Name or alias used to invoke the command.
+     * @param options Parsed command options and arguments.
+     * @param collector Optional collector used for help output.
+     * @return True when help was displayed or the command completed successfully.
+     */
     bool do_run(const std::string command_name, const ParsedOptions& options, const OptionsCollector* collector = nullptr) override {
         if (options.args.count("help") > 0) {
             print_help(command_name, collector);

--- a/include/arkanjo/commands/commands_registry.hpp
+++ b/include/arkanjo/commands/commands_registry.hpp
@@ -5,9 +5,20 @@
 #include <memory>
 #include <arkanjo/commands/command.hpp>
 
+/**
+ * @brief Helpers for resolving CLI command names to command factories.
+ */
 namespace CommandsRegistry {
+    /**
+     * @brief Factory callback used to create a command instance.
+     */
     using CommandFactory = std::function<std::unique_ptr<ICommand>()>;
 
+    /**
+     * @brief Builds a lookup map from every command alias to its factory.
+     * @param commands List of aliases and factory callbacks.
+     * @return Map where each alias points to the factory that creates the command.
+     */
     inline std::unordered_map<std::string, CommandFactory> build_command_map(
         const std::vector<std::pair<std::vector<std::string>, CommandFactory>>& commands
     ) {
@@ -20,6 +31,12 @@ namespace CommandsRegistry {
         return map;
     }
 
+    /**
+     * @brief Creates the command registered for the requested name.
+     * @param name Command name or alias received from the CLI.
+     * @param commands List of aliases and factory callbacks.
+     * @return Command instance when found, otherwise `nullptr`.
+     */
     inline std::unique_ptr<ICommand> get_command(
         const std::string& name, 
         const std::vector<std::pair<std::vector<std::string>, CommandFactory>>& commands

--- a/include/arkanjo/orchestrator.hpp
+++ b/include/arkanjo/orchestrator.hpp
@@ -19,15 +19,23 @@
 
 #include <arkanjo/cli/parser_options.hpp>
 
+/**
+ * @brief Mutable state shared by orchestrator pipeline steps.
+ */
 struct Context {
-    std::string command_name;
-    ParsedOptions options;
-    std::vector<std::string> extra_args;
+    std::string command_name;        ///< Command name selected by the user.
+    ParsedOptions options;           ///< Parsed options for the current command.
+    std::vector<std::string> extra_args; ///< Arguments forwarded to external commands.
 
-    int argc;
-    char** argv;
+    int argc;   ///< Original process argument count.
+    char** argv; ///< Original process argument vector.
 };
 
+/**
+ * @brief Pipeline step that can inspect or update the command context.
+ *
+ * Steps return true to continue the pipeline and false to stop it.
+ */
 using Step = std::function<bool(Context&)>;
 /**
  * @brief Main command orchestrator
@@ -40,12 +48,23 @@ class Orchestrator {
     size_t current_step = 0;
 
   public:
+    /**
+     * @brief Adds a step to the end of the pipeline.
+     * @param step Step callback to execute.
+     */
     void add_step(Step step) { steps.push_back(step); }
 
+    /**
+     * @brief Skips all remaining pipeline steps.
+     */
     void skip() {
         current_step = steps.size();
     }
 
+    /**
+     * @brief Runs each pipeline step until completion or failure.
+     * @param ctx Context shared by all pipeline steps.
+     */
     void run_pipeline(Context& ctx) {
         for (current_step = 0; current_step < steps.size(); ++current_step) {
             if (!steps[current_step] || !steps[current_step](ctx)) {


### PR DESCRIPTION
## Summary
- add Doxygen coverage for CLI option collection and command registry helpers
- document `CommandBase` helper behavior and orchestrator pipeline state
- fill in missing `Function::load` and `Function::print_code` docs

## Validation
- `git diff --check`

## Notes
- `cmake` and `doxygen` are not available in this local environment, so I could not run a native build or regenerate docs here.

Closes #53