### PR TITLE
fix(build): change libgit2 target and header

### DIFF
--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -53,7 +53,7 @@ add_library(core_commands ${CORE_COMMANDS_SOURCES})
 target_sources(core_commands PRIVATE ${GENERATED_FILE})
 
 if(ARKANJO_LIBGIT2_SYSTEM)
-    set(ARKANJO_LIBGIT2_LIBS git2)
+    set(ARKANJO_LIBGIT2_LIBS libgit2::libgit2package)
 else()
     set(ARKANJO_LIBGIT2_LIBS
         libgit2
@@ -66,7 +66,7 @@ else()
 endif()
 target_include_directories(core_commands PUBLIC
     ${ARKANJO_INCLUDE_DIRS}
-    ${libgit2_SOURCE_DIR}/include
+    $<$<NOT:$<BOOL:${ARKANJO_LIBGIT2_SYSTEM}>>:${libgit2_SOURCE_DIR}/include>
 )
 target_link_libraries(core_commands PUBLIC 
     core_base 


### PR DESCRIPTION
The change adds comaptibility with system-installed libgit2 (via packet managers) instead CMake compilated.
When ARKANJO_LIBGIT2_SYSTEM  is ON, find_package expose the lib by its modern libgit2::libgit2package target, not as git2.
The directory include of sources also became optional since libgit2_SOURCE_DIR is not defined in this case.