### PR TITLE
feat: store cache size metadata and use it in preprocessor list (#32)

### DIFF
--- a/include/arkanjo/base/preprocess_state.hpp
+++ b/include/arkanjo/base/preprocess_state.hpp
@@ -12,6 +12,7 @@ struct PreprocessRunParams {
     fs::path path;             ///< Path of the current preprocess
     std::string finished_time; ///< Timing information for when preprocessing finished
     std::string version;       ///< Version of the current preprocess 
+    std::uintmax_t size;       ///< Size of the preprocess output
 };
 
 inline void to_json(json& j, const PreprocessRunParams& d) {
@@ -19,6 +20,7 @@ inline void to_json(json& j, const PreprocessRunParams& d) {
         {"path", d.path.string()},
         {"finished_time", d.finished_time},
         {"version", d.version},
+        {"size", d.size},
     };
 }
 
@@ -26,6 +28,7 @@ inline void from_json(const json& j, PreprocessRunParams& d) {
     d.path = j.value("path", "");
     d.finished_time = j.value("finished_time", "");
     d.version = j.value("version","");
+    d.size = j.value("size", 0);
 }
 
 class Preprocess_State {
@@ -36,8 +39,9 @@ public:
     /**
      * @brief Saves preprocessing parameters for future runs
      * @param path Project path to save
+     * @param cache_path Project cache path
      */
-    static void save_current_run_params(const fs::path& path);
+    static void save_current_run_params(const fs::path& path, const fs::path& cache_path);
 
     /**
      * @brief read preprocessing parameters runs

--- a/src/base/preprocess_state.cpp
+++ b/src/base/preprocess_state.cpp
@@ -2,15 +2,16 @@
 #include <arkanjo/utils/utils.hpp>
 #include <arkanjo/base/config.hpp>
 
-void Preprocess_State::save_current_run_params(const fs::path& path) {
+void Preprocess_State::save_current_run_params(const fs::path& path, const fs::path& cache_path) {
     auto end = std::chrono::system_clock::now();
     std::time_t end_time = std::chrono::system_clock::to_time_t(end);
     std::string time_str(std::ctime(&end_time));
     std::string version = PROJECT_VERSION;
     if (!time_str.empty() && time_str.back() == '\n')
         time_str.pop_back();
+    auto size = Utils::folder_size(cache_path);
 
-    json data = PreprocessRunParams{path, time_str, version};
+    json data = PreprocessRunParams{path, time_str, version, size};
 
     fs::path config_path = Config::config().base_path / Config::config().name_container / CONFIG_PATH;
     Utils::write_file(config_path, data.dump(4) + '\n');

--- a/src/commands/pre/build/preprocessor_build.cpp
+++ b/src/commands/pre/build/preprocessor_build.cpp
@@ -153,7 +153,7 @@ void PreprocessorBuild::preprocess(const fs::path& path, double similarity, size
     if (mode_verbose)
         fm::time("\tExecution time duplication:", start_duplication);
 
-    Preprocess_State::save_current_run_params(path);
+    Preprocess_State::save_current_run_params(path, base_path);
 
     fm::write(END_MESSAGE);
 

--- a/src/commands/pre/list/preprocessor_list.cpp
+++ b/src/commands/pre/list/preprocessor_list.cpp
@@ -1,6 +1,7 @@
 #include "preprocessor_list.hpp"
 
 #include <arkanjo/base/config.hpp>
+#include <arkanjo/base/preprocess_state.hpp>
 
 void PreprocessorList::print_containers(std::vector<ContainerInfo>& containers) {
     size_t color_offset = no_color ? 0 :10;
@@ -37,8 +38,17 @@ bool PreprocessorList::run([[maybe_unused]] const ParsedOptions& options) {
 
         ContainerInfo container;
         container.name = entry.path().filename().string();
+
+        Config::config().name_container = container.name;
+        auto params = Preprocess_State::read_current_run_params();
+
         container.id = Utils::hash(container.name);
-        container.disk_usage = Utils::format_size(Utils::folder_size(entry.path())); 
+
+        container.disk_usage = Utils::format_size(params.size);
+        if (params.size <= 0) {
+            container.disk_usage = Utils::format_size(Utils::folder_size(entry.path()));
+        }
+
         container.extra = "";
         containers.push_back(container);
     }


### PR DESCRIPTION
Store the cache size in the preprocessor configuration file and use this metadata in arkanjo preprocessor list instead of calculating the size on demand. This avoids expensive filesystem scans and significantly reduces the time required to list preprocessors.