### PR TITLE
chore: add pre-commit setup and code quality checks (#45)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,60 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
 IndentWidth: 4
+TabWidth: 4
 UseTab: Never
-TabWidth: 4 
+ColumnLimit: 100
+MaxEmptyLinesToKeep: 1
+SeparateDefinitionBlocks: Always
+
 PointerAlignment: Left
-ColumnLimit: 0
+
+RemoveBracesLLVM: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: false
+  AfterStruct: false
+  AfterClass: false
+  AfterControlStatement: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortFunctionsOnASingleLine: Empty
+
+AlignAfterOpenBracket: BlockIndent
+
 BinPackArguments: false
-AlignAfterOpenBracket: DontAlign
+BinPackParameters: false
+
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllArgumentsOnNextLine: true
+BreakFunctionDefinitionParameters: false
+# Lowers the penalty to prefer breaking the line immediately after the opening (
+PenaltyBreakBeforeFirstCallParameter: 1
+
+AlwaysBreakAfterReturnType: None
+AlwaysBreakAfterDefinitionReturnType: None
+
+# High penalty to prevent the return type from being separated from the function
+# name
+PenaltyReturnTypeOnItsOwnLine: 10000 
+
+AlignOperands: DontAlign
+BreakBeforeTernaryOperators: true
+
+BreakInheritanceList: AfterColon
+PackConstructorInitializers: Never
+
+ReflowComments: false
+
+InsertNewlineAtEOF: true
+
+# TIPS FOR BETTER FORMATTING:
+#
+# 1. In lists, arrays, or initializer lists broken across multiple lines, 
+#    leave a trailing comma after the last element. This generates cleaner 
+#    diffs and makes version control history easier to track.
+#
+# 2. Consider introducing `using` aliases or intermediate variables to 
+#    break down excessively long lines. This prevents awkward line breaks 
+#    from the formatter and greatly improves overall code readability.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+exclude: ^(third-party/|archive/)
+
+repos:
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format (staged files)
+        entry: git-clang-format
+        language: system
+        args:
+          - --staged
+          - --extensions
+          - cpp,hpp,h,cc,cxx
+        pass_filenames: false

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,1 @@
+pre-commit


### PR DESCRIPTION
> [!NOTE]
> Validate whether this PR makes sense for our project.

## Summary

This PR introduces automated code formatting by adding a `.clang-format` configuration and a pre-commit hook.

To validate the configuration, all existing files under `include/` and `src/` were formatted. The resulting diff was very small, showing that the selected style already matches the project's existing formatting closely. This formatting pass also establishes the baseline for future changes.

## Notes for future development

Some long declarations are wrapped to satisfy the configured column limit. When this affects readability, consider introducing `using` aliases or extracting expressions into intermediate variables to keep declarations shorter and easier to follow.

For convenience, a short list of formatting tips has also been added to the end of the `.clang-format` file.

It may also be worth adding a short section to CONTRIBUTING.md explaining how to run the formatter and the pre-commit hook, so contributors can easily follow the project's formatting guidelines. #26 