### PR TITLE
feat: add bootstrap script for Python dependencies

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -11,14 +11,14 @@ runs:
 
     - name: Create venv
       shell: bash
-      run: python -m venv venv
+      run: python -m venv .venv
 
     - name: Add venv to PATH (Linux/macOS)
       if: runner.os != 'Windows'
       shell: bash
-      run: echo "$GITHUB_WORKSPACE/venv/bin" >> $GITHUB_PATH
+      run: echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
     - name: Add venv to PATH (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
-      run: echo "${{ github.workspace }}\venv\Scripts" >> $env:GITHUB_PATH
+      run: echo "${{ github.workspace }}\.venv\Scripts" >> $env:GITHUB_PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,13 @@ jobs:
     - name: Setup environment
       uses: ./.github/actions/setup-env
 
+    - name: Bootstrap environment
+      if: runner.os != 'Windows'
+      run: |
+        ./scripts/bootstrap.sh
+
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements/tfidf.txt
         python -m nltk.downloader punkt punkt_tab
 
     - name: Configure CMake
@@ -38,12 +41,12 @@ jobs:
 
     - name: Run C++ E2E tests
       run: |
-        source venv/bin/activate || call venv\Scripts\activate
+        source .venv/bin/activate || call .venv\Scripts\activate
         ./build/arkanjo-test
 
     - name: Run CLI integration tests
       run: |
-        source venv/bin/activate || call venv\Scripts\activate
+        source .venv/bin/activate || call .venv\Scripts\activate
         echo -e "tests/e2e/codebase\n0.9\n1" | arkanjo preprocessor build
         arkanjo explorer
         arkanjo duplication

--- a/README.md
+++ b/README.md
@@ -55,13 +55,20 @@ git clone https://github.com/arkanjo-tool/arkanjo.git
 cd arkanjo
 ```
 
+Some similarity methods require additional Python dependencies.
+
+See the [**Methods**](#methods) section to check the requirements of the selected
+methods. If any of the enabled methods requires additional dependencies, run:
+
+```sh
+./scripts/bootstrap.sh
+```
+
 Build the binary:
 
 ```sh
-mkdir build && cd build
-
-cmake ..
-cmake --build .
+cmake -B build
+cmake --build build
 ```
 
 The binaries will be generated in the `build/` directory.
@@ -69,7 +76,7 @@ The binaries will be generated in the `build/` directory.
 Optionally, install the binaries using:
 
 ```sh
-cmake --install . [--prefix ~/.local]
+cmake --install build [--prefix ~/.local]
 ```
 
 ## Methods
@@ -78,7 +85,7 @@ ArKanjo supports multiple code duplication detection methods.
 
 See the documentation for details:
 
-- [Methods documentation](docs/methods/)
+- [**Methods documentation**](docs/methods/index.md)
 
 # How to Run
 

--- a/config.json
+++ b/config.json
@@ -3,5 +3,11 @@
     "extensions": {
         "c": [".c", ".h"],
         "rust": [".rs"]
-    }
+    },
+    "methods": [
+        "tfidf",
+        "diff",
+        "ast",
+        "embedding"
+    ]
 }

--- a/docs/methods/index.md
+++ b/docs/methods/index.md
@@ -1,0 +1,21 @@
+# Similarity Methods
+
+ArKanjo supports multiple methods for detecting function-level code duplication.
+
+Each method computes similarity between functions using a different approach.
+Some methods require additional dependencies, while others are fully implemented
+in C++.
+
+## Configuration
+
+Methods are enabled through `config.json`:
+
+```json
+{
+    "methods": [
+        "tfidf",
+        "diff",
+        "ast",
+        "embedding"
+    ]
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONFIG_FILE="$ROOT_DIR/config.json"
+
+BUILD=false
+CMAKE_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build)
+            BUILD=true
+            shift
+            ;;
+        *)
+            CMAKE_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: python3 not found."
+    exit 1
+fi
+
+if ! METHODS=$(python3 "$ROOT_DIR/scripts/get_methods.py" "$CONFIG_FILE"); then
+    echo "Failed to read '$CONFIG_FILE'."
+    exit 1
+fi
+
+if [ -z "$METHODS" ]; then
+    echo "No methods configured."
+    echo "See 'docs/methods' for available methods and configuration" \
+         "instructions."
+    echo "Continuing without installing Python dependencies."
+
+    if [ "$BUILD" = false ]; then
+        exit 0
+    fi
+fi
+
+INSTALL=false
+
+for METHOD in $METHODS; do
+    if [ -f "$ROOT_DIR/requirements/$METHOD.txt" ]; then
+        INSTALL=true
+        break
+    fi
+done
+
+if [ "$INSTALL" = false ]; then
+    echo "No Python dependencies required for the configured methods."
+else
+    for METHOD in $METHODS; do
+        REQUIREMENTS="$ROOT_DIR/requirements/$METHOD.txt"
+
+        if [ -f "$REQUIREMENTS" ]; then
+            echo "Installing Python dependencies for '$METHOD'..."
+            python3 -m pip install -r "$REQUIREMENTS"
+        else
+            echo "Method '$METHOD' does not require Python."
+        fi
+    done
+fi
+
+echo
+echo "Bootstrap completed successfully."
+
+if [ "$BUILD" = true ]; then
+    echo
+    echo "Configuring project..."
+    cmake -B "$ROOT_DIR/build" "${CMAKE_ARGS[@]}"
+
+    echo
+    echo "Building project..."
+    cmake --build "$ROOT_DIR/build"
+
+    echo
+    echo "Build completed successfully."
+fi
+
+echo
+
+if [ -n "${VIRTUAL_ENV:-}" ]; then
+    echo "Python environment:"
+    echo "  $VIRTUAL_ENV"
+elif [ -n "${CONDA_DEFAULT_ENV:-}" ]; then
+    echo "Conda environment:"
+    echo "  $CONDA_DEFAULT_ENV"
+else
+    echo "Make sure the Python environment with the required dependencies is active before running ArKanjo."
+fi

--- a/scripts/get_methods.py
+++ b/scripts/get_methods.py
@@ -1,0 +1,8 @@
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as f:
+    config = json.load(f)
+
+for method in config.get("methods", []):
+    print(method)


### PR DESCRIPTION
Add a script to setup the Python environment based on configured similarity methods.

Some similarity methods require additional Python dependencies, which can make the first-time setup difficult for beginners. This change provides a simpler onboarding experience by automatically preparing the required environment and dependencies.