### PR TITLE
fix(build): Resolve build conflict between Threads and libgit2 (#35)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,12 @@ set(THIRD_PARTY_BUILD_DIR "${CMAKE_BINARY_DIR}/third-party")
 include(cmake/TreeSitter.cmake)
 include(cmake/Libgit2.cmake)
 include(cmake/CompilerOptions.cmake)
-include(cmake/Targets.cmake)
 include(cmake/Documentation.cmake)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+include(cmake/Targets.cmake)
 
 if(ENABLE_TESTS)
     enable_testing()

--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -71,7 +71,7 @@ file(GLOB_RECURSE CORE_METHODS_SOURCES
 add_library(core_methods ${CORE_METHODS_SOURCES})
 target_sources(core_methods PRIVATE ${GENERATED_FILE})
 target_include_directories(core_methods PUBLIC ${ARKANJO_INCLUDE_DIRS})
-target_link_libraries(core_methods PUBLIC core_base ${PARSER_LIBS} tree_sitter_core)
+target_link_libraries(core_methods PUBLIC core_base ${PARSER_LIBS} tree_sitter_core Threads::Threads)
 
 #
 file(GLOB_RECURSE CORE_COMMANDS_SOURCES


### PR DESCRIPTION
The THREADS_PREFER_PTHREAD_FLAG parameter conflicted with the libgit2 build process. Since Threads is used only by the core_methods CMake target, simply reordering the parameter definition was sufficient to resolve the conflict.

Fixes #35 