### PR TITLE
fix(build): Fix NTLK version to avoid install dependecies error (#73)

### DIFF
--- a/requirements/tfidf.txt
+++ b/requirements/tfidf.txt
@@ -1,3 +1,3 @@
 gensim>=3.8
-nltk>=3.5
+nltk==3.10.0
 astor>=0.8.1


### PR DESCRIPTION
Our requirements were relying on the latest version of the NLTK dependency. However, NLTK 3.10.1 is causing build failures in our pipeline. For this reason, this commit pins the NLTK version until we identify the root cause of the build failure.
